### PR TITLE
In-place string and numeric sorting of lists

### DIFF
--- a/compiler/compiler/compiler.c
+++ b/compiler/compiler/compiler.c
@@ -28,6 +28,7 @@ static enum SpecialStrings get_special_string(const struct Node *const node) {
 	else if (STR_EQ(node, "isnum")) return S_ISNUM;
 	else if (STR_EQ(node, "isspace")) return S_ISSPACE;
 	else if (STR_EQ(node, "join")) return S_JOIN;
+	else if (STR_EQ(node, "sort")) return S_SORT;
 	else if (STR_EQ(node, "keys")) return S_KEYS;
 	else if (STR_EQ(node, "ltrim")) return S_LTRIM;
 	else if (STR_EQ(node, "pop")) return S_POP;

--- a/interpreter/VM/VM.c
+++ b/interpreter/VM/VM.c
@@ -60,6 +60,7 @@ struct VM* vm_new(unsigned char *code,    // pointer to bytecode
 	DEF_SPECIAL_STR(S_ISNUM, "isnum");
 	DEF_SPECIAL_STR(S_ISSPACE, "isspace");
 	DEF_SPECIAL_STR(S_JOIN, "join");
+	DEF_SPECIAL_STR(S_SORT, "sort");
 	DEF_SPECIAL_STR(S_KEYS, "keys");
 	DEF_SPECIAL_STR(S_LTRIM, "ltrim");
 	DEF_SPECIAL_STR(S_POP, "pop");

--- a/interpreter/YASL_Object/YASL_Object.c
+++ b/interpreter/YASL_Object/YASL_Object.c
@@ -116,6 +116,31 @@ struct YASL_Object *YASL_CFunction(int (*value)(struct YASL_State *), int num_ar
     return fn;
 }
 
+int yasl_object_cmp(struct YASL_Object a, struct YASL_Object b) {
+	if (YASL_ISSTR(a) && YASL_ISSTR(b)) {
+		return yasl_string_cmp(YASL_GETSTR(a), YASL_GETSTR(b));
+	} else if (YASL_ISNUM(a) && YASL_ISNUM(b)) {
+		double aVal, bVal;
+		if(YASL_ISINT(a)) {
+			aVal = a.value.ival;
+		} else {
+			aVal = a.value.dval;
+		}
+		if(YASL_ISINT(b)) {
+			bVal = b.value.ival;
+		} else {
+			bVal = b.value.dval;
+		}
+
+		if (aVal < bVal) return -1;
+		if (aVal > bVal) return 1;
+		return 0;
+	} else {
+		printf("Cannot apply object compare to types %s and %s.\n", YASL_TYPE_NAMES[a.type], YASL_TYPE_NAMES[b.type]);
+		exit(-1);
+	}
+}
+
 int isfalsey(struct YASL_Object v) {
     // TODO: add NaN as falsey
     return (

--- a/interpreter/YASL_Object/YASL_Object.h
+++ b/interpreter/YASL_Object/YASL_Object.h
@@ -104,6 +104,11 @@ struct YASL_Object *YASL_UserPointer(void *userdata);
 struct YASL_Object *YASL_Function(int64_t index);
 struct YASL_Object *YASL_CFunction(int (*value)(struct YASL_State *), int num_args);
 
+/*
+ * Either both types are strings or both types are numerical. Otherwise error
+ */
+int yasl_object_cmp(struct YASL_Object a, struct YASL_Object b);
+
 int isfalsey(struct YASL_Object v);
 struct YASL_Object isequal(struct YASL_Object a, struct YASL_Object b);
 int print(struct YASL_Object a);

--- a/interpreter/YASL_string/YASL_string.c
+++ b/interpreter/YASL_string/YASL_string.c
@@ -15,7 +15,8 @@ int64_t yasl_string_cmp(const String_t *const left, const String_t *const right)
         int64_t tmp = memcmp(left->str + left->start, right->str + right->start, yasl_string_len(left));
         return tmp ? tmp : -1;
     } else {
-        return memcmp(left->str + left->start, right->str + right->start, yasl_string_len(right)) || 1;
+        int64_t tmp = memcmp(left->str + left->start, right->str + right->start, yasl_string_len(right));
+		return tmp ? tmp : 1;
     }
 }
 

--- a/interpreter/builtins/builtins.c
+++ b/interpreter/builtins/builtins.c
@@ -105,6 +105,7 @@ struct Table* list_builtins(struct VM *vm) {
 	table_insert_specialstring_cfunction(vm, table, S_SLICE, &list_slice, 3);
 	table_insert_specialstring_cfunction(vm, table, S_CLEAR, &list_clear, 1);
 	table_insert_specialstring_cfunction(vm, table, S_JOIN, &list_join, 2);
+	table_insert_specialstring_cfunction(vm, table, S_SORT, &list_sort, 1);
 	return table;
 }
 

--- a/interpreter/list/list_methods.c
+++ b/interpreter/list/list_methods.c
@@ -342,3 +342,104 @@ int list_join(struct YASL_State *S) {
 	vm_pushstr(S->vm, str_new_sized_heap(0, buffer_count, buffer));
 	return 0;
 }
+
+const int SORT_TYPE_EMPTY = 0;
+const int SORT_TYPE_STR = -1;
+const int SORT_TYPE_NUM = 1;
+void sort(struct YASL_Object *list, const size_t len) {
+	// Base cases
+	struct YASL_Object tmpObj;
+	if (len < 2) return;
+	if (len == 2) {
+		if (yasl_object_cmp(list[0], list[1]) > 0) {
+			tmpObj = list[0];
+			list[0] = list[1];
+			list[1] = tmpObj;
+		}
+		return;
+	}
+
+	// Set sorting bounds
+	size_t left = 0;
+	size_t right = len-1;
+
+	// Determine random midpoint to use (good average case)
+	const size_t randIndex = rand() % len;
+	const struct YASL_Object mid = list[randIndex];
+
+	// Determine exact number of items less than mid (mid's index)
+	// Furthermore, ensure list is not homogenous to avoid infinite loops
+	size_t ltCount = 0;
+	int seenDifferent = 0;
+	for(size_t i = 0; i < len; i++) {
+		if(yasl_object_cmp(list[i], mid) < 0) ltCount++;
+		if(seenDifferent == 0 && yasl_object_cmp(list[0], list[i]) != 0) seenDifferent = 1;
+	}
+	if (seenDifferent == 0) return;
+
+	// Ensure all items are on the correct side of mid
+	while (left < right) {
+		while (yasl_object_cmp(list[left], mid) < 0) left++;
+		while (yasl_object_cmp(list[right], mid) >= 0) {
+			if (right == 0) break;
+			right--;
+		}
+
+		int cmp = yasl_object_cmp(list[left], list[right]);
+		if (cmp > 0 && left < right) {
+			tmpObj = list[right];
+			list[right] = list[left];
+			list[left++] = tmpObj;
+			if(right == 0) break;
+			right--;
+		} else if (cmp == 0) {
+			left++;
+			if(right == 0) break;
+			right--;
+		}
+	}
+
+	// Let sort() finish that for us...
+	sort(list, ltCount);
+	sort(&list[ltCount], len - ltCount);
+}
+int list_sort(struct YASL_State *S) {
+	ASSERT_TYPE(S->vm, Y_LIST, "list.sort");
+	struct List *list = vm_poplist(S->vm);
+	int type = SORT_TYPE_EMPTY;
+
+	int err = 0;
+	for (int64_t i = 0; i < list->count; i++) {
+		switch (list->items[i].type) {
+		case Y_STR:
+			if (type == SORT_TYPE_EMPTY) {
+				type = SORT_TYPE_STR;
+			} else if (type == SORT_TYPE_NUM) {
+				err = -1;
+			}
+			break;
+		case Y_INT:
+		case Y_FLOAT:
+			if (type == SORT_TYPE_EMPTY) {
+				type = SORT_TYPE_NUM;
+			} else if (type == SORT_TYPE_STR) {
+				err = -1;
+			}
+			break;
+		default:
+			err = -1;
+		}
+
+		if (err != 0) {
+			printf("Only lists containing all strings or all numbers can be sorted.\n");
+			return err;
+		}
+	}
+
+	if (type != SORT_TYPE_EMPTY) {
+		sort(list->items, list->count);
+	}
+
+	vm_pushundef(S->vm);
+	return 0;
+}

--- a/interpreter/list/list_methods.h
+++ b/interpreter/list/list_methods.h
@@ -25,3 +25,5 @@ int list_slice(struct YASL_State *S);
 int list_clear(struct YASL_State *S);
 
 int list_join(struct YASL_State *S);
+
+int list_sort(struct YASL_State *S);

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "yasl.h"
 #include "yasl-std-io.h"
@@ -8,6 +9,9 @@
 #define VERSION "v0.3.3"
 
 int main(int argc, char** argv) {
+	// Initialize prng seed
+	srand(time(NULL));
+
     if (argc > 2) {
         puts("ERROR: Too many arguments passed. Type `yasl -h` for help (without the backticks).");
         return EXIT_FAILURE;

--- a/opcode.h
+++ b/opcode.h
@@ -106,8 +106,6 @@ enum SpecialStrings {
 
 	S_JOIN,       // join
 
-	S_SORT,       // sort
-
 	S_KEYS,       // keys
 
 	S_LTRIM,      // ltrim
@@ -122,6 +120,7 @@ enum SpecialStrings {
 
 	S_SEARCH,     // search
 	S_SLICE,      // slice
+	S_SORT,       // sort
 	S_SPLIT,      // split
 	S_STARTSWITH, // startswith
 

--- a/opcode.h
+++ b/opcode.h
@@ -106,6 +106,8 @@ enum SpecialStrings {
 
 	S_JOIN,       // join
 
+	S_SORT,       // sort
+
 	S_KEYS,       // keys
 
 	S_LTRIM,      // ltrim


### PR DESCRIPTION
Devised a relatively simple divide and conquer alg that should be avg O(n*lgn) time. Also I fixed a comparison bug in yasl_string_cmp method. This commit is meant to address issue #78 