### PR TITLE
Improved primality testing

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "yasl.h"
 #include "yasl-std-io.h"
@@ -9,6 +10,9 @@
 #define VERSION "v0.3.3"
 
 int main(int argc, char** argv) {
+	// Initialize prng seed
+	srand(time(NULL));
+
     if (argc > 2) {
         puts("ERROR: Too many arguments passed. Type `yasl -h` for help (without the backticks).");
         return EXIT_FAILURE;

--- a/prime/prime.c
+++ b/prime/prime.c
@@ -8,8 +8,8 @@ const int64_t PRIMES_UNDER_200[] = {2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,
 int is_prime(const int64_t x) {
     if (x < 2) return -1;
     if (x < 4) return 1;
-	int i;
-	for (i = 0; i < sizeof(PRIMES_UNDER_200)/sizeof(int64_t); i++) {
+	int64_t i;
+	for (i = 0; i < (int64_t)(sizeof(PRIMES_UNDER_200)/sizeof(int64_t)); i++) {
 		if ((x % PRIMES_UNDER_200[i]) == 0) {
             return 0;
         }

--- a/prime/prime.c
+++ b/prime/prime.c
@@ -1,18 +1,65 @@
+#include <stdlib.h>
 #include <math.h>
 #include "prime.h"
+
+const int64_t PRIMES_UNDER_200[] = {2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199};
 
 // returns 1 -- prime, 0 -- not prime, -1 -- undefined
 int is_prime(const int64_t x) {
     if (x < 2) return -1;
     if (x < 4) return 1;
-    if ((x % 2) == 0) return 0;
-    int i;
-    for (i = 3; i <= floor(sqrt((double)x)); i += 2) {
+	int i;
+	for (i = 0; i < sizeof(PRIMES_UNDER_200)/sizeof(int64_t); i++) {
+		if ((x % PRIMES_UNDER_200[i]) == 0) {
+            return 0;
+        }
+	}
+    for (i = 201; i <= floor(sqrt((double)x)); i += 2) {
         if ((x % i) == 0) {
             return 0;
         }
     }
     return 1;
+}
+
+int64_t exp_mod_helper(int64_t base, int64_t exp, const int64_t p) {
+	while (exp < 0) exp += (p-1);
+	exp %= p-1;
+
+	int64_t r = 1;
+	int64_t i = 1;
+	while (i <= exp && i != 0) {
+		if ((exp & i) != 0) r = (r * base) % p;
+		base = (base*base) % p; i <<= 1;
+	}
+	return r;
+}
+// returns 1 -- prime, 0 -- not prime, -1 -- undefined
+int prob_is_prime(const int64_t x, const int64_t count) {
+	// bounds..
+	if (x < 2 || count < 1) return -1;
+
+	// For small numbers, less is more
+	if (x < 1000000) return is_prime(x);
+
+	// Apply Miller-Rabin probablistic primality test
+	int64_t r = 1;
+	int64_t d = (x - 1) >> 1;
+	while (d % 2 == 0) {r++; d >>= 1;}
+	// Ensure 'a' can be squared without overflowing int64_t
+	const int64_t max = 3037000498 < x-3 ? 3037000498 : x-3;
+	for (int64_t i = 0; i < count; i++) {
+		int64_t a = (rand() % max) + 2;
+		int64_t b = exp_mod_helper(a, d, x);
+		if (b == 1 || b == x - 1) continue;
+		int64_t j = 0;
+		for (; j < r-1; j++) {
+			b = (b*b) % x;
+			if (b == x - 1) break;
+		}
+		if (j == r - 1) return 0;
+	}
+	return 1;
 }
 
 int64_t next_prime(int64_t x) {

--- a/prime/prime.c
+++ b/prime/prime.c
@@ -2,7 +2,7 @@
 #include <math.h>
 #include "prime.h"
 
-const int64_t PRIMES_UNDER_200[] = {2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199};
+const int64_t PRIMES_UNDER_200[] = {2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199};
 
 // returns 1 -- prime, 0 -- not prime, -1 -- undefined
 int is_prime(const int64_t x) {
@@ -10,9 +10,8 @@ int is_prime(const int64_t x) {
     if (x < 4) return 1;
 	int64_t i;
 	for (i = 0; i < (int64_t)(sizeof(PRIMES_UNDER_200)/sizeof(int64_t)); i++) {
-		if ((x % PRIMES_UNDER_200[i]) == 0) {
-            return 0;
-        }
+		if (x == PRIMES_UNDER_200[i]) return 1;
+		if ((x % PRIMES_UNDER_200[i]) == 0) return 0;
 	}
     for (i = 201; i <= floor(sqrt((double)x)); i += 2) {
         if ((x % i) == 0) {

--- a/prime/prime.h
+++ b/prime/prime.h
@@ -6,4 +6,5 @@
 #define PRIME_B 67
 
 int is_prime(const int64_t x);
+int prob_is_prime(const int64_t x, const int64_t count);
 int64_t next_prime(int64_t x);

--- a/test/inputs/math.yasl
+++ b/test/inputs/math.yasl
@@ -1,4 +1,4 @@
-##true\n180.0\n0.20788\n1.0\ntrue\n10.0\ntrue\ntrue\ntrue\n48\n15360\ntrue\ntrue\n
+##true\n180.0\n0.20788\n1.0\ntrue\n10.0\ntrue\ntrue\ntrue\n48\n15360\ntrue\nfalse\ntrue\n
 
 fn inEpsilon(a, b) {
 	return math.abs(a - b) < 10**-10
@@ -28,7 +28,8 @@ echo math.gcd(3072, 240)
 echo math.lcm(3072, 240)
 
 # Type casts to integer
-echo math.isprime(15485867.5)
+echo math.isprime(15485867.6)
+echo math.isprime(15485869.1)
 
 x := 18408990
 echo math.isprime(x-1) && math.isprime(x+1)

--- a/test/inputs/math.yasl
+++ b/test/inputs/math.yasl
@@ -1,4 +1,4 @@
-##true\n180.0\n0.20788\n1.0\ntrue\n10.0\ntrue\ntrue\ntrue\n
+##true\n180.0\n0.20788\n1.0\ntrue\n10.0\ntrue\ntrue\ntrue\n48\n15360\ntrue\ntrue\n
 
 fn inEpsilon(a, b) {
 	return math.abs(a - b) < 10**-10
@@ -21,3 +21,14 @@ echo math.sqrt(0.5) == math.cos(math.pi / 4)
 echo inEpsilon(math.asin(0.5), math.rad(30))
 
 echo inEpsilon(math.tan(1984), math.sin(1984)/math.cos(1984))
+
+## Number theory
+echo math.gcd(3072, 240)
+
+echo math.lcm(3072, 240)
+
+# Type casts to integer
+echo math.isprime(15485867.5)
+
+x := 18408990
+echo math.isprime(x-1) && math.isprime(x+1)

--- a/test/vmtest.pl
+++ b/test/vmtest.pl
@@ -78,7 +78,7 @@ assert_output(qq"x := { x*2:-x for x <- [1, 2, 3]}
                       echo i
                       echo x[i]
                  }\n",
-              "2\n-1\n4\n-2\n6\n-3\n", 0);
+              "2\n-1\n6\n-3\n4\n-2\n", 0);
 
 
 # Unary Operators
@@ -277,14 +277,14 @@ assert_output(qq"x := [1, 2, 3, [1, 2, 3]]
  
 # Table Methods
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'}
-                 echo x->keys()\n", "[2, 1, 3]\n", 0);
+                 echo x->keys()\n", "[3, 2, 1]\n", 0);
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'}
-                 echo x->values()\n", "[two, one, three]\n", 0);
+                 echo x->values()\n", "[three, two, one]\n", 0);
 assert_output(qq"x := { 3:'three', 1:'one', 2:'two'}
                  x[1] = 'un'
-                 echo x\n", "{2: two, 1: un, 3: three}\n", 0);
+                 echo x\n", "{3: three, 2: two, 1: un}\n", 0);
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'};
-                 for e <- x->copy() { echo e; echo x[e]; };", "2\ntwo\n1\none\n3\nthree\n", 0);
+                 for e <- x->copy() { echo e; echo x[e]; };", "3\nthree\n2\ntwo\n1\none\n", 0);
 assert_output(qq"echo {}\n", "{}\n", 0);
 assert_output(qq"y := []
                  x := {}

--- a/test/vmtest.pl
+++ b/test/vmtest.pl
@@ -78,7 +78,7 @@ assert_output(qq"x := { x*2:-x for x <- [1, 2, 3]}
                       echo i
                       echo x[i]
                  }\n",
-              "2\n-1\n6\n-3\n4\n-2\n", 0);
+              "2\n-1\n4\n-2\n6\n-3\n", 0);
 
 
 # Unary Operators
@@ -277,14 +277,14 @@ assert_output(qq"x := [1, 2, 3, [1, 2, 3]]
  
 # Table Methods
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'}
-                 echo x->keys()\n", "[3, 2, 1]\n", 0);
+                 echo x->keys()\n", "[2, 1, 3]\n", 0);
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'}
-                 echo x->values()\n", "[three, two, one]\n", 0);
+                 echo x->values()\n", "[two, one, three]\n", 0);
 assert_output(qq"x := { 3:'three', 1:'one', 2:'two'}
                  x[1] = 'un'
-                 echo x\n", "{3: three, 2: two, 1: un}\n", 0);
+                 echo x\n", "{2: two, 1: un, 3: three}\n", 0);
 assert_output(qq"x := {1:'one', 2:'two', 3:'three'};
-                 for e <- x->copy() { echo e; echo x[e]; };", "3\nthree\n2\ntwo\n1\none\n", 0);
+                 for e <- x->copy() { echo e; echo x[e]; };", "2\ntwo\n1\none\n3\nthree\n", 0);
 assert_output(qq"echo {}\n", "{}\n", 0);
 assert_output(qq"y := []
                  x := {}


### PR DESCRIPTION
I've added a function, `prob_is_prime()`, for performing probablistic primality testing (Miller-Rabin) when the input is sufficiently large. It calls `is_prime()` for small inputs. Note that the probability of error is `4**-count`. I have not switched the internal code to call this new function (because I assume all internally needed primes are fairly small) but I think it's important for at least the math library to test primality quickly for large inputs.