### PR TITLE
issue #101 compile with MSVC(Win32)

### DIFF
--- a/compiler/compiler/compiler.c
+++ b/compiler/compiler/compiler.c
@@ -9,6 +9,7 @@
 #include "yasl_error.h"
 #include "yasl_include.h"
 #include "compiler/lexer/lexinput.h"
+#include <math.h>
 
 #define break_checkpoint(compiler)    ((compiler)->checkpoints[(compiler)->checkpoints_count-1])
 #define continue_checkpoint(compiler) ((compiler)->checkpoints[(compiler)->checkpoints_count-2])
@@ -829,7 +830,7 @@ static void visit_Float(struct Compiler *const compiler, const struct Node *cons
 		bb_add_byte(compiler->buffer, DCONST_2);
 	} else if (val != val) {
 		bb_add_byte(compiler->buffer, DCONST_N);
-	} else if (val == 1.0 / 0.0) {
+	} else if (isinf(val)) {
 		bb_add_byte(compiler->buffer, DCONST_I);
 	} else {
 		bb_add_byte(compiler->buffer, DCONST);

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -686,3 +686,22 @@ static struct Node *parse_collection(Parser *const parser) {
         return new_List(keys, parser->lex.line);
     }
 }
+
+#ifdef _MSC_VER
+// To avoid MSVC _VA_ARGS_ macro expansion bug
+int token_matches(Parser *parser, ...) {
+    va_list ap;
+    int ret = 0;
+    va_start(ap, parser);
+    for (;;) {
+        Token tok = va_arg(ap, Token);
+        if (tok == -1) break;
+        if (curtok(parser) == tok) {
+            ret = 1;
+            break;
+ 	}
+    }
+    va_end(ap);
+    return ret;
+}
+#endif

--- a/compiler/parser/parser.h
+++ b/compiler/parser/parser.h
@@ -28,3 +28,11 @@ int peof(const Parser *parser);
 void parser_cleanup(Parser *const parser);
 Token eattok(Parser *parser, Token token);
 struct Node *parse(Parser *parser);
+
+#ifdef _MSC_VER
+#include <stdarg.h>
+// To avoid MSVC _VA_ARGS_ macro expansion bug
+int token_matches(Parser *parser, ...);
+#undef TOKEN_MATCHES
+#define TOKEN_MATCHES(px, ...) token_matches(parser, __VA_ARGS__, (Token)-1)
+#endif

--- a/interpreter/VM/VM.c
+++ b/interpreter/VM/VM.c
@@ -271,8 +271,9 @@ int vm_num_unop(struct VM *vm, yasl_int (*int_op)(yasl_int), yasl_float (*float_
 int vm_stringify_top(struct VM *vm) {
 	YASL_Types index = VM_PEEK(vm, vm->sp).type;
 	if (YASL_ISFN(VM_PEEK(vm, vm->sp)) || YASL_ISCFN(VM_PEEK(vm, vm->sp))) {
-		char *buffer = malloc(snprintf(NULL, 0, "<fn: %d>", (int)vm_peek(vm).value.ival) + 1);
-		sprintf(buffer, "<fn: %d>", (int)vm_peek(vm).value.ival);
+		int n;	  
+		char *buffer = malloc(n = snprintf(NULL, 0, "<fn: %d>", (int)vm_peek(vm).value.ival) + 1);
+		snprintf(buffer, n, "<fn: %d>", (int)vm_peek(vm).value.ival);
 		vm_pushstr(vm, str_new_sized_heap(0, strlen(buffer), buffer));
 	} else {
 		struct YASL_Object key = YASL_STR(str_new_sized(strlen("tostr"), "tostr"));
@@ -327,7 +328,7 @@ int vm_NEWSPECIALSTR(struct VM *vm) {
 int vm_NEWSTR(struct VM *vm) {
 	yasl_int addr = vm_read_int(vm);
 
-	size_t size;
+	yasl_int size;
 	memcpy(&size, vm->code + addr, sizeof(yasl_int));
 
 	addr += sizeof(yasl_int);
@@ -453,10 +454,10 @@ int vm_run(struct VM *vm) {
 			vm_pushfloat(vm, opcode - DCONST_0); // make sure no changes to opcodes ruin this
 			break;
 		case DCONST_N:
-			vm_pushfloat(vm, 0.0 / 0.0);
+			vm_pushfloat(vm, NAN);
 			break;
 		case DCONST_I:
-			vm_pushfloat(vm, 1.0 / 0.0);
+			vm_pushfloat(vm, INFINITY);
 			break;
 		case DCONST:        // constants have native endianness
 			d = vm_read_float(vm);

--- a/interpreter/YASL_string/str_methods.c
+++ b/interpreter/YASL_string/str_methods.c
@@ -77,14 +77,14 @@ int isvaliddouble(const char *str) {
 }
 
 double parsedouble(const char *str) {
-	if (!strcmp(str, "inf") || !strcmp(str, "+inf")) return 1.0 / 0.0;
-	else if (!strcmp(str, "-inf")) return -1.0 / 0.0;
+	if (!strcmp(str, "inf") || !strcmp(str, "+inf")) return INFINITY;
+	else if (!strcmp(str, "-inf")) return -INFINITY;
 	else if (str[0] == '-' && isvaliddouble(str+1))
 		return -strtod(str+1, NULL);
 	else if (str[0] == '+' && isvaliddouble(str+1))
 		return +strtod(str+1, NULL);
 	else if (isvaliddouble(str))	return strtod(str, NULL);
-	return 0.0 / 0.0;
+	return NAN;
 }
 
 int64_t parseint64(const char *str) {

--- a/interpreter/float/yasl_float.c
+++ b/interpreter/float/yasl_float.c
@@ -6,7 +6,7 @@
 char *float64_to_str(double d) {
 	int64_t size = snprintf(NULL, 0, "%f", d);
 	char *ptr = malloc(size + 1);
-	sprintf(ptr, "%f", d);
+	snprintf(ptr, size+1, "%f", d);
 	while (ptr[size - 1] == '0' && ptr[size - 2] != '.') {
 		size--;
 	}

--- a/interpreter/integer/int_methods.c
+++ b/interpreter/integer/int_methods.c
@@ -13,8 +13,9 @@ int int_tofloat(struct YASL_State *S) {
 int int_tostr(struct YASL_State *S) {
     ASSERT_TYPE((struct VM *)S, Y_INT, "int64.tostr");
     yasl_int val = YASL_GETINT(vm_pop((struct VM *)S));
-    char *ptr = malloc(snprintf(NULL, 0, "%" PRId64 "", val) + 1);
-    sprintf(ptr, "%" PRId64 "", val);
+    int n;
+    char *ptr = malloc(n = snprintf(NULL, 0, "%" PRId64 "", val) + 1);
+    snprintf(ptr, n,"%" PRId64 "", val);
     String_t* string = str_new_sized_heap(0, snprintf(NULL, 0, "%" PRId64 "", val), ptr);
     vm_push((struct VM *)S, YASL_STR(string));
     return 0;

--- a/std-io/yasl-std-io.c
+++ b/std-io/yasl-std-io.c
@@ -29,7 +29,7 @@ int YASL_io_open(struct YASL_State *S) {
         return -1;
     }
 
-    FILE *f;
+    FILE *f = 0;
     if (mode_len == 1) {
         switch (mode_str[0]) {
             case 'r':

--- a/std-math/yasl-std-math.c
+++ b/std-math/yasl-std-math.c
@@ -17,8 +17,13 @@
                     }
 
 const double YASL_PI = 3.14159265358979323851280895940618620443274267017841339111328125;
+#if _MSC_VER
+const double YASL_NAN = NAN;
+const double YASL_INF = INFINITY;
+#else
 const double YASL_NAN = 0.0 / 0.0;
 const double YASL_INF = 1.0 / 0.0;
+#endif
 
 int YASL_math_abs(struct YASL_State *S) {
 	POP_NUMBER(S, num, "math.abs");

--- a/yasl_conf.h
+++ b/yasl_conf.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <stdint.h>
 #include <inttypes.h>
 
 // Which floating point type YASL will use.


### PR DESCRIPTION
in order to compile yasl with MSVC;
```
- MSVC causes error for using sprintf
- MSVC cannot compile division by 0 constant; 0.0/0.0 is changed to NAN, and also use INFINITY.
- MSVC _VA_ARGS_ macro expansion bug work around; adding function to emulate intention
- MSVC cannot treat int64_t without stdint.h
- size of size_t is different from yasl_int
```