### PR TITLE
workaround for hashtable overflow

### DIFF
--- a/hashtable/hashtable.c
+++ b/hashtable/hashtable.c
@@ -34,7 +34,7 @@ static int hash_function(const struct YASL_Object s, const int a, const int m) {
 static unsigned int get_hash(const struct YASL_Object s, const int num_buckets, const int attempt) {
         const int hash_a = hash_function(s, PRIME_A, num_buckets);
         if (attempt == 0)
-                return hash_a % num_buckets;
+                return ((unsigned int)hash_a) % num_buckets;
         const int hash_b = hash_function(s, PRIME_B, num_buckets);
         return ((unsigned int)(hash_a + (attempt * (hash_b + 1)))) % num_buckets;
 }
@@ -135,7 +135,7 @@ static void table_resize_down(struct Table *table) {
 
 void table_insert(struct Table *table, const struct YASL_Object key, const struct YASL_Object value) {
 		const int load = table->count * 100 / table->size;
-        if (load > 70) table_resize_up(table);
+        if (load > 70) { resize: table_resize_up(table); }
         Item_t item = new_item(key, value);
         int index = get_hash(item.key, table->size, 0);
         Item_t curr_item = table->items[index];
@@ -148,6 +148,7 @@ void table_insert(struct Table *table, const struct YASL_Object key, const struc
                                 return;
                         }
                 }
+		if ((unsigned int)i >= table->size) goto resize;
                 index = get_hash(item.key, table->size, i++);
                 curr_item = table->items[index];
         }


### PR DESCRIPTION
logically when searching hashtable, index must be below table size. there was no checking it.
so check and table overflow detection then resize table are added. 