### PR TITLE
V0.3.7

### DIFF
--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -647,7 +647,7 @@ static void visit_Print(struct Compiler *const compiler, const struct Node *cons
 
 static void declare_with_let_or_const(struct Compiler *const compiler, const struct Node *const node) {
 	if (contains_var_in_current_scope(compiler, node->value.sval.str, node->value.sval.str_len)) {
-		YASL_PRINT_ERROR_SYNTAX("Illegal redeclaration of %s in line %zd.\n", node->value.sval.str, node->line);
+		YASL_PRINT_ERROR_SYNTAX("Illegal redeclaration of %s (line %zd).\n", node->value.sval.str, node->line);
 		handle_error(compiler);
 		return;
 	}

--- a/compiler/env.c
+++ b/compiler/env.c
@@ -76,11 +76,12 @@ int64_t env_get(Env_t *env, char *name, size_t name_len) {
 	return value.value.ival;
 }
 
-void env_decl_var(Env_t *env, char *name, size_t name_len) {
+int64_t env_decl_var(Env_t *env, char *name, size_t name_len) {
 	String_t *string = str_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
 	struct YASL_Object key = YASL_STR(string);
 	struct YASL_Object value = YASL_INT(env_len(env));
 	table_insert(env->vars, key, value);
+	return env_len(env);
 }
 
 static struct Table *get_closest_scope_with_var(Env_t *env, char *name, size_t name_len) {

--- a/compiler/env.h
+++ b/compiler/env.h
@@ -20,5 +20,5 @@ size_t env_len(Env_t *env);
 int env_contains_cur_scope(Env_t *env, char *name, size_t name_len);
 int env_contains(Env_t *env, char *name, size_t name_len);
 int64_t env_get(Env_t *env, char *name, size_t name_len);
-void env_decl_var(Env_t *env, char *name, size_t name_len);
+int64_t env_decl_var(Env_t *env, char *name, size_t name_len);
 void env_make_const(Env_t *env, char *name, size_t name_len);

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -685,6 +685,7 @@ static int matches_keyword(Lexer *lex, char *string) {
 static void set_keyword(Lexer *lex, enum Token type) {
 	lex->type = type;
 	free(lex->value);
+	lex->value = NULL;
 }
 
 static void YASLKeywords(Lexer *lex) {

--- a/hashtable/hashtable.c
+++ b/hashtable/hashtable.c
@@ -14,192 +14,194 @@
 #define HT_BASESIZE 30
 
 static int hash_function(const struct YASL_Object s, const int a, const int m) {
-        long hash = 0;
-        if (YASL_ISSTR(s)) {
-                const int64_t len_s = yasl_string_len(s.value.sval);
-                for (int i = 0; i < len_s; i++) {
-                        hash = (hash * a) ^ (s.value.sval->str + s.value.sval->start)[i];
-                        hash %= m;
-                }
-                return (int) hash;
-        } else {
-				long ll = s.value.ival & 0xFFFF;
-				long lu = (s.value.ival & 0xFFFF0000) >> 16;
-				long ul = (s.value.ival & 0xFFFF00000000) >> 32;
-				long uu = (s.value.ival & 0xFFFF000000000000) >> 48;
-                return (int) (((long) a*ll*ll*ll*ll ^ a*a*lu*lu*lu ^ a*a*a*ul*ul ^ a*a*a*a*uu) % m);
-        }
+	long hash = 0;
+	if (YASL_ISSTR(s)) {
+		const int64_t len_s = yasl_string_len(s.value.sval);
+		for (int i = 0; i < len_s; i++) {
+			hash = (hash * a) ^ (s.value.sval->str + s.value.sval->start)[i];
+			hash %= m;
+		}
+		return (int) hash;
+	} else {
+		long ll = s.value.ival & 0xFFFF;
+		long lu = (s.value.ival & 0xFFFF0000) >> 16;
+		long ul = (s.value.ival & 0xFFFF00000000) >> 32;
+		long uu = (s.value.ival & 0xFFFF000000000000) >> 48;
+		return (int) (((long) a * ll * ll * ll * ll ^ a * a * lu * lu * lu ^ a * a * a * ul * ul ^
+			       a * a * a * a * uu) % m);
+	}
 }
 
 static unsigned int get_hash(const struct YASL_Object s, const int num_buckets, const int attempt) {
-        const int hash_a = hash_function(s, PRIME_A, num_buckets);
-        if (attempt == 0)
-                return hash_a % num_buckets;
-        const int hash_b = hash_function(s, PRIME_B, num_buckets);
-        return ((unsigned int)(hash_a + (attempt * (hash_b + 1)))) % num_buckets;
+	const int hash_a = hash_function(s, PRIME_A, num_buckets);
+	if (attempt == 0) {
+		return hash_a % num_buckets;
+	}
+	const int hash_b = hash_function(s, PRIME_B, num_buckets);
+	return ((unsigned int) (hash_a + (attempt * (hash_b + (hash_b == 0))))) % num_buckets;
 }
 
 static Item_t new_item(const struct YASL_Object k, const struct YASL_Object v) {
-        Item_t item = {k, v};
-        inc_ref(&item.value);
-        inc_ref(&item.key);
-        return item;
+	Item_t item = {k, v};
+	inc_ref(&item.value);
+	inc_ref(&item.key);
+	return item;
 }
 
 void del_item(Item_t *item) {
-        dec_ref(&item->key);
-        dec_ref(&item->value);
+	dec_ref(&item->key);
+	dec_ref(&item->value);
 }
 
 struct Table *table_new_sized(const int base_size) {
-        struct Table *table = malloc(sizeof(struct Table));
-        table->base_size = base_size;
-        table->size = next_prime(table->base_size);
-        table->count = 0;
-        table->items = calloc((size_t) table->size, sizeof(Item_t));
-        return table;
+	struct Table *table = malloc(sizeof(struct Table));
+	table->base_size = base_size;
+	table->size = next_prime(table->base_size);
+	table->count = 0;
+	table->items = calloc((size_t) table->size, sizeof(Item_t));
+	return table;
 }
 
 struct Table *table_new(void) {
-        return table_new_sized(HT_BASESIZE);
+	return table_new_sized(HT_BASESIZE);
 }
 
 void table_del(struct Table *table) {
-        FOR_TABLE(i, item, table) {
-                del_item(item);
-        }
-        free(table->items);
-        free(table);
+	FOR_TABLE(i, item, table) {
+		del_item(item);
+	}
+	free(table->items);
+	free(table);
 }
 
 struct RC_UserData *rcht_new_sized(const int base_size) {
-        struct RC_UserData *ht = malloc(sizeof(struct RC_UserData));
-        ht->data = table_new_sized(base_size);
-        ht->rc = rc_new();
-        ht->tag = T_TABLE;
-        return ht;
+	struct RC_UserData *ht = malloc(sizeof(struct RC_UserData));
+	ht->data = table_new_sized(base_size);
+	ht->rc = rc_new();
+	ht->tag = T_TABLE;
+	return ht;
 }
 
 struct RC_UserData *rcht_new() {
-        return rcht_new_sized(HT_BASESIZE);
+	return rcht_new_sized(HT_BASESIZE);
 }
 
 void rcht_del(struct RC_UserData *hashtable) {
-        table_del(hashtable->data);
-        rc_del(hashtable->rc);
-        free(hashtable);
+	table_del(hashtable->data);
+	rc_del(hashtable->rc);
+	free(hashtable);
 }
 
 void rcht_del_data(struct RC_UserData *hashtable) {
-        table_del(hashtable->data);
+	table_del(hashtable->data);
 }
 
 void rcht_del_rc(struct RC_UserData *hashtable) {
-        rc_del(hashtable->rc);
-        free(hashtable);
+	rc_del(hashtable->rc);
+	free(hashtable);
 }
 
 void table_del_string_int(struct Table *table) {
-        table_del(table);
+	table_del(table);
 }
 
 static void table_resize(struct Table *table, const int base_size) {
-        if (base_size < HT_BASESIZE) return;
-        struct Table *new_table = table_new_sized(base_size);
-        FOR_TABLE(i, item, table) {
-                table_insert(new_table, item->key, item->value);
-        }
-        table->base_size = new_table->base_size;
-        table->count = new_table->count;
+	if (base_size < HT_BASESIZE) return;
+	struct Table *new_table = table_new_sized(base_size);
+	FOR_TABLE(i, item, table) {
+		table_insert(new_table, item->key, item->value);
+	}
+	table->base_size = new_table->base_size;
+	table->count = new_table->count;
 
-        const size_t tmp_size = table->size;
-        table->size = new_table->size;
-        new_table->size = tmp_size;
+	const size_t tmp_size = table->size;
+	table->size = new_table->size;
+	new_table->size = tmp_size;
 
-        Item_t *tmp_items = table->items;
-        table->items = new_table->items;
-        new_table->items = tmp_items;
+	Item_t *tmp_items = table->items;
+	table->items = new_table->items;
+	new_table->items = tmp_items;
 
-        table_del(new_table);
+	table_del(new_table);
 }
 
 static void table_resize_up(struct Table *table) {
-        const size_t new_size = table->base_size * 2;
-        table_resize(table, new_size);
+	const size_t new_size = table->base_size * 2;
+	table_resize(table, new_size);
 }
 
 static void table_resize_down(struct Table *table) {
-        const size_t new_size = table->base_size / 2;
-        table_resize(table, new_size);
+	const size_t new_size = table->base_size / 2;
+	table_resize(table, new_size);
 }
 
 void table_insert(struct Table *table, const struct YASL_Object key, const struct YASL_Object value) {
-		const int load = table->count * 100 / table->size;
-        if (load > 70) table_resize_up(table);
-        Item_t item = new_item(key, value);
-        int index = get_hash(item.key, table->size, 0);
-        Item_t curr_item = table->items[index];
-        int i = 1;
-        while (!YASL_ISUNDEF(curr_item.key)) {
-				if (curr_item.key.type != Y_END) {
-                        if (!isfalsey(isequal(curr_item.key, item.key))) {
-                                del_item(&curr_item);
-                                table->items[index] = item;
-                                return;
-                        }
-                }
-                index = get_hash(item.key, table->size, i++);
-                curr_item = table->items[index];
-        }
-        table->items[index] = item;
-        table->count++;
+	const int load = table->count * 100 / table->size;
+	if (load > 70) table_resize_up(table);
+	Item_t item = new_item(key, value);
+	int index = get_hash(item.key, table->size, 0);
+	Item_t curr_item = table->items[index];
+	int i = 1;
+	while (!YASL_ISUNDEF(curr_item.key)) {
+		if (curr_item.key.type != Y_END) {
+			if (!isfalsey(isequal(curr_item.key, item.key))) {
+				del_item(&curr_item);
+				table->items[index] = item;
+				return;
+			}
+		}
+		index = get_hash(item.key, table->size, i++);
+		curr_item = table->items[index];
+	}
+	table->items[index] = item;
+	table->count++;
 }
 
 void table_insert_string_int(struct Table *table, char *key, int64_t key_len, int64_t val) {
-        String_t *string = str_new_sized_heap(0, key_len, copy_char_buffer(key_len, key));
-        table_insert(table,
-                     (struct YASL_Object) {.type = Y_STR, .value.sval = string},
-                     (struct YASL_Object) {.type = Y_INT, .value.ival = val});
+	String_t *string = str_new_sized_heap(0, key_len, copy_char_buffer(key_len, key));
+	table_insert(table,
+		     (struct YASL_Object) {.type = Y_STR, .value.sval = string},
+		     (struct YASL_Object) {.type = Y_INT, .value.ival = val});
 }
 
 struct YASL_Object table_search(const struct Table *const table, const struct YASL_Object key) {
-        size_t index = get_hash(key, table->size, 0);
-        Item_t item = table->items[index];
-        int i = 1;
-        while (!YASL_ISUNDEF(item.key)) {
-                if (!isfalsey(isequal(item.key, key))) {
-                        return item.value;
-                }
-                index = get_hash(key, table->size, i++);
-                item = table->items[index];
-        }
-        return (struct YASL_Object) {Y_END, {0}};
+	size_t index = get_hash(key, table->size, 0);
+	Item_t item = table->items[index];
+	int i = 1;
+	while (!YASL_ISUNDEF(item.key)) {
+		if (!isfalsey(isequal(item.key, key))) {
+			return item.value;
+		}
+		index = get_hash(key, table->size, i++);
+		item = table->items[index];
+	}
+	return (struct YASL_Object) {Y_END, {0}};
 }
 
 struct YASL_Object table_search_string_int(const struct Table *const table, char *key, int64_t key_len) {
-        String_t *string = str_new_sized_heap(0, key_len, copy_char_buffer(key_len, key));
-        struct YASL_Object object = (struct YASL_Object) {.value.sval = string, .type = Y_STR};
+	String_t *string = str_new_sized_heap(0, key_len, copy_char_buffer(key_len, key));
+	struct YASL_Object object = (struct YASL_Object) {.value.sval = string, .type = Y_STR};
 
-        struct YASL_Object result = table_search(table, object);
-        str_del(string);
-        return result;
+	struct YASL_Object result = table_search(table, object);
+	str_del(string);
+	return result;
 }
 
 void table_rm(struct Table *table, struct YASL_Object key) {
-        const int load = table->count * 100 / table->size;
-        if (load < 10) table_resize_down(table);
-        int index = get_hash(key, table->size, 0);
-        Item_t item = table->items[index];
-        int i = 1;
-        while (!YASL_ISUNDEF(item.key)) {
-                if (item.key.type != Y_END) {
-                        if (!isfalsey(isequal(item.key, key))) {
-                                del_item(&item);
-                                table->items[index] = TOMBSTONE;
-                        }
-                }
-                index = get_hash(key, table->size, i++);
-                item = table->items[index];
-        }
-        table->count--;
+	const int load = table->count * 100 / table->size;
+	if (load < 10) table_resize_down(table);
+	int index = get_hash(key, table->size, 0);
+	Item_t item = table->items[index];
+	int i = 1;
+	while (!YASL_ISUNDEF(item.key)) {
+		if (item.key.type != Y_END) {
+			if (!isfalsey(isequal(item.key, key))) {
+				del_item(&item);
+				table->items[index] = TOMBSTONE;
+			}
+		}
+		index = get_hash(key, table->size, i++);
+		item = table->items[index];
+	}
+	table->count--;
 }

--- a/hashtable/hashtable.c
+++ b/hashtable/hashtable.c
@@ -35,7 +35,7 @@ static int hash_function(const struct YASL_Object s, const int a, const int m) {
 static unsigned int get_hash(const struct YASL_Object s, const int num_buckets, const int attempt) {
 	const int hash_a = hash_function(s, PRIME_A, num_buckets);
 	if (attempt == 0) {
-		return hash_a % num_buckets;
+		return ((unsigned int)hash_a) % num_buckets;
 	}
 	const int hash_b = hash_function(s, PRIME_B, num_buckets);
 	return ((unsigned int) (hash_a + (attempt * (hash_b + (hash_b == 0))))) % num_buckets;

--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@
 #include "yasl-std-math.h"
 #include "yasl_state.h"
 
-#define VERSION "v0.3.6"
+#define VERSION "v0.3.7"
 #define VERSION_PRINTOUT "YASL " VERSION
 
 static int main_error(int argc, char **argv) {

--- a/test/clitest.pl
+++ b/test/clitest.pl
@@ -25,7 +25,7 @@ sub assert_output {
     return $exitcode;
 }
 
-assert_output("YASL -V", "YASL v0.3.6\n", 0);
+assert_output("YASL -V", "YASL v0.3.7\n", 0);
 assert_output("YASL -h",
               "usage: yasl [option] [file]\n" .
               "options:\n" .

--- a/yasl.c
+++ b/yasl.c
@@ -95,7 +95,10 @@ int YASL_execute(struct YASL_State *S) {
 
 
 int YASL_declglobal(struct YASL_State *S, char *name) {
-    env_decl_var(S->compiler.globals, name, strlen(name));
+    int64_t index = env_decl_var(S->compiler.globals, name, strlen(name));
+    if (index > 255) {
+        return YASL_TOO_MANY_VAR_ERROR;
+    }
     return YASL_SUCCESS;
 }
 

--- a/yasl.c
+++ b/yasl.c
@@ -51,7 +51,7 @@ void YASL_resetstate_bb(struct YASL_State *S, char *buf, size_t len) {
 	S->compiler.parser.lex = NEW_LEXER(lexinput_new_bb(buf, len));
 	S->compiler.code->count = 0;
 	S->compiler.buffer->count = 0;
-	S->compiler.header->count = 16;
+	// S->compiler.header->count = 16;
 	table_del_string_int(S->compiler.strings);
 	S->compiler.strings = table_new();
 	free(S->vm.code);
@@ -59,10 +59,10 @@ void YASL_resetstate_bb(struct YASL_State *S, char *buf, size_t len) {
 
 
 int YASL_delstate(struct YASL_State *S) {
-    compiler_cleanup(&S->compiler);
+	compiler_cleanup(&S->compiler);
 	vm_cleanup((struct VM *) S);
-    free(S);
-    return YASL_SUCCESS;
+	free(S);
+	return YASL_SUCCESS;
 }
 
 int YASL_execute_REPL(struct YASL_State *S) {
@@ -80,17 +80,17 @@ int YASL_execute_REPL(struct YASL_State *S) {
 }
 
 int YASL_execute(struct YASL_State *S) {
-    unsigned char *bc = compile(&S->compiler);
-    if (!bc) return S->compiler.status;
+	unsigned char *bc = compile(&S->compiler);
+	if (!bc) return S->compiler.status;
 
-    int64_t entry_point = *((int64_t*)bc);
-    // TODO: use this in VM.
-    // int64_t num_globals = *((int64_t*)bc+1);
+	int64_t entry_point = *((int64_t *) bc);
+	// TODO: use this in VM.
+	// int64_t num_globals = *((int64_t*)bc+1);
 
-    S->vm.pc = entry_point;
-    S->vm.code = bc;
+	S->vm.pc = entry_point;
+	S->vm.code = bc;
 
-    return vm_run((struct VM *)S);  // TODO: error handling for runtime errors.
+	return vm_run((struct VM *) S);  // TODO: error handling for runtime errors.
 }
 
 

--- a/yasl_error.h
+++ b/yasl_error.h
@@ -5,10 +5,11 @@
  */
 
 enum YASL_Error {
-	YASL_SUCCESS,       // Successful execution.
-	YASL_ERROR,         // Generic error.
-	YASL_INIT_ERROR,    // YASL_State has not been correctly initialised.
-	YASL_SYNTAX_ERROR,  // Syntax error during compilation.
-	YASL_TYPE_ERROR,    // Type error (at runtime).
-	YASL_DIVIDE_BY_ZERO_ERROR // Division by zero error (at runtime).
+	YASL_SUCCESS,              // Successful execution.
+	YASL_ERROR,                // Generic error.
+	YASL_INIT_ERROR,           // YASL_State has not been correctly initialised.
+	YASL_SYNTAX_ERROR,         // Syntax error during compilation.
+	YASL_TYPE_ERROR,           // Type error (at runtime).
+	YASL_DIVIDE_BY_ZERO_ERROR, // Division by zero error (at runtime).
+	YASL_TOO_MANY_VAR_ERROR    // Too many variables in current scope
 };

--- a/yasl_include.h
+++ b/yasl_include.h
@@ -19,4 +19,4 @@
 #define YASL_PRINT_ERROR_UNDECLARED_VAR(name, line) YASL_PRINT_ERROR_SYNTAX("Undeclared variable %s (line %zd).\n", name, line)
 #define YASL_PRINT_ERROR_CONSTANT(name, line) YASL_PRINT_ERROR_SYNTAX("Cannot assign to constant %s (line %zd).\n", name, line)
 #define YASL_PRINT_ERROR_TOO_MANY_VAR(line) YASL_PRINT_ERROR("Too many variables in current scope (line %zd).\n", line)
-#define YASL_PRINT_ERROR_DIVIDE_BY_ZERO() printf(K_RED "DivisionByZeroError" K_END "\n")
+#define YASL_PRINT_ERROR_DIVIDE_BY_ZERO() printf(K_RED "DivisionByZeroError\n" K_END)

--- a/yasl_include.h
+++ b/yasl_include.h
@@ -18,4 +18,5 @@
 
 #define YASL_PRINT_ERROR_UNDECLARED_VAR(name, line) YASL_PRINT_ERROR_SYNTAX("Undeclared variable %s (line %zd).\n", name, line)
 #define YASL_PRINT_ERROR_CONSTANT(name, line) YASL_PRINT_ERROR_SYNTAX("Cannot assign to constant %s (line %zd).\n", name, line)
+#define YASL_PRINT_ERROR_TOO_MANY_VAR(line) YASL_PRINT_ERROR("Too many variables in current scope (line %zd).\n", line)
 #define YASL_PRINT_ERROR_DIVIDE_BY_ZERO() printf(K_RED "DivisionByZeroError" K_END "\n")


### PR DESCRIPTION
Bug Fixes:
- Fixed bug where double hashing failed in some cases (which caused compiles to take up to 5 minutes for small scripts).
- Too many variables in a given scope now raises an error instead of breaking. (current limit per scope is 256.)
- Fixed segfault that happened when parsing and a keyword showed up unexpectedly in some cases.
- Fixed segfault in REPL when calling user defined functions.

Internal Changes:
- Added tests for certain "failing" behaviours such as division by 0, type errors, assigning to constant, etc.