### PR TITLE
v0.6.6

### DIFF
--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "compiler/token.h"
+#include "token.h"
 #include "yasl_conf.h"
 
 // NOTE: _MUST_ keep this up to date with the jumptable in compiler.c and the jumptable in middleend.c

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -1,16 +1,16 @@
 #include "compiler.h"
 
+#include <math.h>
+
 #include "ast.h"
-#include "interpreter/YASL_Object.h"
-#include "middleend.h"
 #include "data-structures/YASL_String.h"
 #include "data-structures/YASL_ByteBuffer.h"
+#include "interpreter/YASL_Object.h"
+#include "lexinput.h"
+#include "middleend.h"
 #include "parser.h"
 #include "yasl_error.h"
 #include "yasl_include.h"
-#include "lexinput.h"
-
-#include <math.h>
 
 #define compiler_print_err(compiler, format, ...) {\
 	char *tmp = (char *)malloc(snprintf(NULL, 0, format, __VA_ARGS__) + 1);\
@@ -146,11 +146,11 @@ static void enter_scope(struct Compiler *const compiler) {
 static void exit_scope(struct Compiler *const compiler) {
 	if (in_function(compiler)) {
 		compiler->num_locals += compiler->params->vars->count;
-		Env_t *tmp = compiler->params;
+		struct Env *tmp = compiler->params;
 		compiler->params = compiler->params->parent;
 		env_del_current_only(tmp);
 	} else {
-		Env_t *tmp = compiler->stack;
+		struct Env *tmp = compiler->stack;
 		compiler->stack = compiler->stack->parent;
 		env_del_current_only(tmp);
 	}
@@ -443,7 +443,7 @@ static void visit_FunctionDecl(struct Compiler *const compiler, const struct Nod
 	compiler->buffer->count = old_size;
 	// compiler->buffer->count = 0;
 
-	Env_t *tmp = compiler->params->parent;
+	struct Env *tmp = compiler->params->parent;
 	env_del_current_only(compiler->params);
 	compiler->params = tmp;
 

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -4,11 +4,9 @@
 
 #include "ast.h"
 #include "data-structures/YASL_String.h"
-#include "data-structures/YASL_ByteBuffer.h"
-#include "interpreter/YASL_Object.h"
 #include "lexinput.h"
 #include "middleend.h"
-#include "parser.h"
+#include "opcode.h"
 #include "yasl_error.h"
 #include "yasl_include.h"
 

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <inttypes.h>
+
 #include "compiler/ast.h"
-#include "parser.h"
 #include "data-structures/YASL_ByteBuffer.h"
-#include "opcode.h"
-#include "env.h"
 #include "debug.h"
+#include "env.h"
 #include "IO.h"
+#include "opcode.h"
+#include "parser.h"
 
 #define NEW_COMPILER(fp)\
   ((struct Compiler) {\
@@ -29,9 +30,9 @@
 
 struct Compiler {
     struct Parser parser;
-    Env_t *globals;
-    Env_t *stack;
-    Env_t *params;
+    struct Env *globals;
+    struct Env *stack;
+    struct Env *params;
     size_t num_locals;
     struct YASL_Table *strings;
     struct YASL_ByteBuffer *buffer;

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -2,12 +2,9 @@
 
 #include <inttypes.h>
 
-#include "compiler/ast.h"
 #include "data-structures/YASL_ByteBuffer.h"
 #include "debug.h"
 #include "env.h"
-#include "IO.h"
-#include "opcode.h"
 #include "parser.h"
 
 #define NEW_COMPILER(fp)\

--- a/compiler/env.c
+++ b/compiler/env.c
@@ -5,21 +5,21 @@
 #include "data-structures/YASL_String.h"
 #include "interpreter/YASL_Object.h"
 
-Env_t *env_new(Env_t *parent) {
-	Env_t *env = (Env_t *)malloc(sizeof(Env_t));
+struct Env *env_new(struct Env *parent) {
+	struct Env *env = (struct Env *)malloc(sizeof(struct Env));
 	env->parent = parent;
 	env->vars = YASL_Table_new();
 	return env;
 }
 
-void env_del(Env_t *env) {
+void env_del(struct Env *env) {
 	if (env == NULL) return;
 	env_del(env->parent);
 	free(env->parent);
 	env_del_current_only(env);
 }
 
-void env_del_current_only(Env_t *env) {
+void env_del_current_only(struct Env *env) {
 	for (size_t i = 0; i < env->vars->size; i++) {
 		struct YASL_Table_Item *item = &env->vars->items[i];
 		if (item->key.type != Y_END && item->key.type != Y_UNDEF) {
@@ -32,12 +32,12 @@ void env_del_current_only(Env_t *env) {
 	free(env);
 }
 
-size_t env_len(const Env_t *const env) {
+size_t env_len(const struct Env *const env) {
 	if (env == NULL) return 0;
 	return env->vars->count + env_len(env->parent);
 }
 
-int env_contains_cur_scope(const Env_t *const env, const char *const name, const size_t name_len) {
+int env_contains_cur_scope(const struct Env *const env, const char *const name, const size_t name_len) {
 	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
 	struct YASL_Object key = YASL_STR(string); // (struct YASL_Object) { .value.sval = string, .type = Y_STR };
 
@@ -49,7 +49,7 @@ int env_contains_cur_scope(const Env_t *const env, const char *const name, const
 	return 1;
 }
 
-int env_contains(const Env_t *const env, const char *const name, const size_t name_len) {
+int env_contains(const struct Env *const env, const char *const name, const size_t name_len) {
 	if (env == NULL) return 0;
 	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
 	struct YASL_Object key = YASL_STR(string);
@@ -63,7 +63,7 @@ int env_contains(const Env_t *const env, const char *const name, const size_t na
 	return 1;
 }
 
-int64_t env_get(const Env_t *const env, const char *const name, const size_t name_len) {
+int64_t env_get(const struct Env *const env, const char *const name, const size_t name_len) {
 	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
 	struct YASL_Object key = YASL_STR(string);
 
@@ -78,7 +78,7 @@ int64_t env_get(const Env_t *const env, const char *const name, const size_t nam
 	return value.value.ival;
 }
 
-int64_t env_decl_var(Env_t *const env, const char *const name, const size_t name_len) {
+int64_t env_decl_var(struct Env *const env, const char *const name, const size_t name_len) {
 	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
 	struct YASL_Object key = YASL_STR(string);
 	struct YASL_Object value = YASL_INT((long)env_len(env));
@@ -86,12 +86,12 @@ int64_t env_decl_var(Env_t *const env, const char *const name, const size_t name
 	return env_len(env);
 }
 
-static struct YASL_Table *get_closest_scope_with_var(const Env_t *const env, const char *const name, const size_t name_len) {
+static struct YASL_Table *get_closest_scope_with_var(const struct Env *const env, const char *const name, const size_t name_len) {
 	struct YASL_Object key = YASL_Table_search_string_int(env->vars, name, name_len);
 	return key.type != Y_END ? env->vars : get_closest_scope_with_var(env->parent, name, name_len);
 }
 
-void env_make_const(Env_t *const env, const char *const name, const size_t name_len) {
+void env_make_const(struct Env *const env, const char *const name, const size_t name_len) {
 	struct YASL_Table *ht = get_closest_scope_with_var(env, name, name_len);
 	YASL_Table_insert_string_int(ht, name, name_len, ~YASL_Table_search_string_int(ht, name, name_len).value.ival);
 }

--- a/compiler/env.c
+++ b/compiler/env.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 
 #include "data-structures/YASL_String.h"
-#include "interpreter/YASL_Object.h"
 
 struct Env *env_new(struct Env *parent) {
 	struct Env *env = (struct Env *)malloc(sizeof(struct Env));

--- a/compiler/env.h
+++ b/compiler/env.h
@@ -1,24 +1,19 @@
-//
-// Created by thiabaud on 01/05/18.
-//
-#include "data-structures/YASL_Table.h"
-#include "data-structures/YASL_String.h"
-#include <string.h>
+#pragma once
 
-struct Env_s {
-    struct Env_s *parent;
+#include "data-structures/YASL_Table.h"
+
+struct Env {
+    struct Env *parent;
     struct YASL_Table *vars;
 };
 
-typedef struct Env_s Env_t;
+struct Env *env_new(struct Env *env);
+void env_del(struct Env *env);
+void env_del_current_only(struct Env *env);
 
-Env_t *env_new(Env_t *env);
-void env_del(Env_t *env);
-void env_del_current_only(Env_t *env);
-
-size_t env_len(const Env_t *const env);
-int env_contains_cur_scope(const Env_t *const env, const char *const name, const size_t name_len);
-int env_contains(const Env_t *const env, const char *const name, const size_t name_len);
-int64_t env_get(const Env_t *const env, const char *const name, const size_t name_len);
-int64_t env_decl_var(Env_t *const env, const char *const name, const size_t name_len);
-void env_make_const(Env_t *const env,  const char *const name, const size_t name_len);
+size_t env_len(const struct Env *const env);
+int env_contains_cur_scope(const struct Env *const env, const char *const name, const size_t name_len);
+int env_contains(const struct Env *const env, const char *const name, const size_t name_len);
+int64_t env_get(const struct Env *const env, const char *const name, const size_t name_len);
+int64_t env_decl_var(struct Env *const env, const char *const name, const size_t name_len);
+void env_make_const(struct Env *const env,  const char *const name, const size_t name_len);

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -202,9 +202,15 @@ static bool lex_eatint(struct Lexer *lex, char separator, int (*isvaliddigit)(in
 	return false;
 }
 
+static void lex_eatnumber_fill(struct Lexer *lex) {
+	do {
+		lex_val_append(lex, lex->c);
+		lex_getchar(lex);
+		while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
+	} while (!lxeof(lex->file) && isdigit(lex->c));
+}
+
 static bool lex_eatfloat(struct Lexer *lex) {
-	//int curr_pos = lxtell(lex->file);
-	//int curr_char = lex->c;
 	if (lex->c == '.') {
 		lex_getchar(lex);
 		if (lxeof(lex->file)) {
@@ -216,21 +222,13 @@ static bool lex_eatfloat(struct Lexer *lex) {
 			return true;
 		}
 		lex_val_append(lex, '.');
-		do {
-			lex_val_append(lex, lex->c);
-			lex_getchar(lex);
-			while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
-		} while (!lxeof(lex->file) && isdigit(lex->c));
+		lex_eatnumber_fill(lex);
 
 		if (tolower(lex->c) == 'e') {
 			lex_getchar(lex);
 			lex_val_append(lex, 'e');
 			while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
-			do {
-				lex_val_append(lex, lex->c);
-				lex_getchar(lex);
-				while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
-			} while (!lxeof(lex->file) && isdigit(lex->c));
+			lex_eatnumber_fill(lex);
 		}
 
 		lex_val_append(lex, '\0');
@@ -252,11 +250,7 @@ static bool lex_eatnumber(struct Lexer *lex) {
 		if (lex_eatint(lex, 'b', &isbdigit)) return true;
 
 		// decimal (or first half of float)
-		do {
-			lex_val_append(lex, lex->c);
-			lex_getchar(lex);
-			while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
-		} while (!lxeof(lex->file) && ((isdigit(lex->c))));
+		lex_eatnumber_fill(lex);
 
 		while (lex->c == NUM_SEPERATOR) lex_getchar(lex);
 		lex->type = T_INT;

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -4,8 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "compiler/token.h"
 #include "debug.h"
+#include "token.h"
 #include "yasl_error.h"
 #include "yasl_include.h"
 

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -404,8 +404,6 @@ void lex_eatinterpstringbody(struct Lexer *lex) {
 
 	if (lex_eatinterpstring_fill(lex)) return;
 
-	lex->val_cap = lex->val_len;
-
 	if (lxeof(lex->file)) {
 		lex_print_err_syntax(lex,  "Unclosed string literal in line %" PRI_SIZET ".\n", lex->line);
 		lex_error(lex);
@@ -441,8 +439,6 @@ static bool lex_eatstring(struct Lexer *lex) {
 			lex_checkbuffer(lex);
 		}
 
-		lex->val_cap = lex->val_len;
-
 		if (lxeof(lex->file)) {
 			lex_print_err_syntax(lex, "Unclosed string literal in line %" PRI_SIZET ".\n", lex->line);
 			lex_error(lex);
@@ -467,8 +463,6 @@ static bool lex_eatrawstring(struct Lexer *lex) {
 			lex_getchar(lex);
 			lex_checkbuffer(lex);
 		}
-
-		lex->val_cap = lex->val_len;
 
 		if (lxeof(lex->file)) {
 			lex_print_err_syntax(lex, "Unclosed string literal in line %" PRI_SIZET ".\n", lex->line);

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -1,6 +1,7 @@
 #include "lexer.h"
 
 #include <ctype.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "compiler/token.h"

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdbool.h>
+
 #include "token.h"
 #include "lexinput.h"
 #include "IO.h"
@@ -15,6 +17,7 @@
 	     .type = T_UNKNOWN,\
 	     .value = NULL,\
 	     .val_len = 0,\
+	     .val_cap = 0,\
 	     .line = 1,\
 	     .status = YASL_SUCCESS,\
 	     .mode = L_NORMAL,\
@@ -38,6 +41,7 @@ struct Lexer {
     char c;
     enum Token type;
     char *value;             // NOT OWN
+    size_t val_cap;
     size_t val_len;
     size_t line;
     int status;
@@ -48,8 +52,7 @@ struct Lexer {
 // struct Lexer *lex_new(FILE *file);
 void lex_cleanup(struct Lexer *lex);
 void gettok(struct Lexer *lex);
-int lex_eatinterpstringbody(struct Lexer *lex);
-int lex_eatfloatexp(struct Lexer *lex);
+void lex_eatinterpstringbody(struct Lexer *lex);
 void lex_error(struct Lexer *lex);
 int lex_getchar(struct Lexer *lex);
 

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -14,14 +14,14 @@
 #define NEW_LEXER(f) \
   ((struct Lexer) { .file = (f),\
              .c = 0,\
-	     .type = T_UNKNOWN,\
-	     .value = NULL,\
-	     .val_len = 0,\
-	     .val_cap = 0,\
-	     .line = 1,\
-	     .status = YASL_SUCCESS,\
-	     .mode = L_NORMAL,\
-	     .err = ((struct IO) { io_print_file, stderr, NULL, 0 })\
+             .type = T_UNKNOWN,\
+             .value = NULL,\
+             .val_cap = 0,\
+             .val_len = 0,\
+             .line = 1,\
+             .status = YASL_SUCCESS,\
+             .mode = L_NORMAL,\
+             .err = ((struct IO) { io_print_file, stderr, NULL, 0 })\
 })
 
 #define ESCAPE_CHAR '\\'

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -2,9 +2,9 @@
 
 #include <stdbool.h>
 
-#include "token.h"
-#include "lexinput.h"
 #include "IO.h"
+#include "lexinput.h"
+#include "token.h"
 
 #define  ispotentialend(l) ((l)->type == T_ID || (l)->type == T_STR || \
             (l)->type == T_INT || (l)->type == T_FLOAT || (l)->type == T_BREAK || \

--- a/compiler/lexinput.c
+++ b/compiler/lexinput.c
@@ -1,5 +1,7 @@
 #include "lexinput.h"
 
+#include "data-structures/YASL_ByteBuffer.h"
+
 struct LEXINPUT {
   FILE *fp;
   struct YASL_ByteBuffer *bb;

--- a/compiler/lexinput.c
+++ b/compiler/lexinput.c
@@ -61,7 +61,7 @@ static  int lexinput_file_close(struct LEXINPUT *const lp) {
 }
 
 struct LEXINPUT *lexinput_new_file(FILE *const fp) {
-	struct LEXINPUT *lp = (struct LEXINPUT *) malloc(sizeof(struct LEXINPUT));
+	struct LEXINPUT *lp = (struct LEXINPUT *)malloc(sizeof(struct LEXINPUT));
 	lp->fp = fp;
 	lp->getc = lexinput_file_getc;
 	lp->tell = lexinput_file_tell;

--- a/compiler/lexinput.h
+++ b/compiler/lexinput.h
@@ -2,8 +2,6 @@
 
 #include <stdio.h>
 
-#include "data-structures/YASL_ByteBuffer.h"
-
 struct LEXINPUT;
 struct LEXINPUT *lexinput_new_file(FILE *const lp);
 struct LEXINPUT *lexinput_new_bb(const char *const buf, const size_t len);

--- a/compiler/middleend.c
+++ b/compiler/middleend.c
@@ -551,9 +551,9 @@ static void (*jumptable[])(struct Node *const ) = {
 	&fold_ExprStmt,
 	&fold_Block,
 	&fold_Body,
-	NULL,
-	NULL,
-	NULL,
+	NULL, // Function Decl
+	NULL, // Return
+	NULL, // Export
 	&fold_Call,
 	&fold_MethodCall,
 	&fold_Set,
@@ -586,6 +586,5 @@ static void (*jumptable[])(struct Node *const ) = {
 };
 
 void fold(struct Node *const node) {
-
 	jumptable[node->nodetype](node);
 }

--- a/compiler/middleend.h
+++ b/compiler/middleend.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "ast.h"
 
 void fold(struct Node *const node);

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -247,9 +247,6 @@ static struct Node *parse_fn(struct Parser *const parser) {
 static struct Node *parse_const(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("parsing const in line %" PRI_SIZET "\n", parser->lex.line);
 	eattok(parser, T_CONST);
-	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_len;
-	size_t line = parser->lex.line;
 	if (matcheattok(parser, T_FN)) {
 		size_t line = parser->lex.line;
 		char *name = parser->lex.value;
@@ -265,6 +262,9 @@ static struct Node *parse_const(struct Parser *const parser) {
 		memcpy(name2, name, name_len);
 		return new_Const(name, name_len, new_FnDecl(block, body, name2, name_len, parser->lex.line), line);
 	}
+	char *name = parser->lex.value;
+	size_t name_len = strlen(name);
+	size_t line = parser->lex.line;
 	eattok(parser, T_ID);
 	eattok(parser, T_EQ);
 	struct Node *expr = parse_expr(parser);
@@ -577,7 +577,7 @@ static struct Node *parse_call(struct Parser *const parser) {
 static struct Node *parse_constant(struct Parser *const parser) {
 	switch (curtok(parser)) {
 	case T_DOT:eattok(parser, T_DOT); {
-		struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
+		struct Node *cur_node = new_String(parser->lex.value, strlen(parser->lex.value), parser->lex.line);
 		eattok(parser, T_ID);
 		return cur_node;
 	  }

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -2,9 +2,9 @@
 
 #include <inttypes.h>
 
-#include "compiler/ast.h"
-#include "compiler/middleend.h"
+#include "ast.h"
 #include "debug.h"
+#include "middleend.h"
 #include "yasl_conf.h"
 #include "yasl_error.h"
 #include "yasl_include.h"

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -214,13 +214,13 @@ static struct Node *parse_fn(struct Parser *const parser) {
 	eattok(parser, T_FN);
 	size_t line = parser->lex.line;
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_cap;
+	size_t name_len = strlen(name);
 	eattok(parser, T_ID);
 	if (matcheattok(parser, T_DOT)) {
 		struct Node *collection = new_Var(name, name_len, line);
 		size_t line = parser->lex.line;
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_cap;
+		size_t name_len = strlen(name);
 		eattok(parser, T_ID);
 
 		struct Node *index = new_String(name, name_len, line);
@@ -248,12 +248,12 @@ static struct Node *parse_const(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("parsing const in line %" PRI_SIZET "\n", parser->lex.line);
 	eattok(parser, T_CONST);
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_cap;
+	size_t name_len = parser->lex.val_len;
 	size_t line = parser->lex.line;
 	if (matcheattok(parser, T_FN)) {
 		size_t line = parser->lex.line;
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_cap;
+		size_t name_len = strlen(name);
 		eattok(parser, T_ID);
 		eattok(parser, T_LPAR);
 		struct Node *block = parse_function_params(parser);
@@ -279,7 +279,7 @@ static struct Node *parse_decl(struct Parser *const parser) {
 	do {
 		eattok(parser, T_LET);
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_cap;
+		size_t name_len = strlen(name);
 		size_t line = parser->lex.line;
 		eattok(parser, T_ID);
 		body_append(&buffer, new_Let(name, name_len, NULL, line));
@@ -301,7 +301,7 @@ static struct Node *parse_let(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("parsing let in line %" PRI_SIZET "\n", parser->lex.line);
 	eattok(parser, T_LET);
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_cap;
+	size_t name_len = strlen(name);
 	size_t line = parser->lex.line;
 	eattok(parser, T_ID);
 	eattok(parser, T_EQ);
@@ -314,7 +314,7 @@ static struct Node *parse_let_iterate_or_let(struct Parser *const parser) {
 		return parse_let(parser);
 	} else {
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_cap;
+		size_t name_len = strlen(name);
 		size_t line = parser->lex.line;
 		eattok(parser, T_ID);
 		eattok(parser, T_LEFT_ARR);
@@ -577,7 +577,7 @@ static struct Node *parse_call(struct Parser *const parser) {
 static struct Node *parse_constant(struct Parser *const parser) {
 	switch (curtok(parser)) {
 	case T_DOT:eattok(parser, T_DOT); {
-		struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
+		struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
 		eattok(parser, T_ID);
 		return cur_node;
 	  }
@@ -618,7 +618,7 @@ static struct Node *parse_constant(struct Parser *const parser) {
 
 static struct Node *parse_id(struct Parser *const parser) {
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_cap;
+	size_t name_len = strlen(name);
 	size_t line = parser->lex.line;
 	eattok(parser, T_ID);
 	YASL_PARSE_DEBUG_LOG("%s\n", "Parsing variable");

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -214,13 +214,13 @@ static struct Node *parse_fn(struct Parser *const parser) {
 	eattok(parser, T_FN);
 	size_t line = parser->lex.line;
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_len;
+	size_t name_len = parser->lex.val_cap;
 	eattok(parser, T_ID);
 	if (matcheattok(parser, T_DOT)) {
 		struct Node *collection = new_Var(name, name_len, line);
 		size_t line = parser->lex.line;
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_len;
+		size_t name_len = parser->lex.val_cap;
 		eattok(parser, T_ID);
 
 		struct Node *index = new_String(name, name_len, line);
@@ -248,12 +248,12 @@ static struct Node *parse_const(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("parsing const in line %" PRI_SIZET "\n", parser->lex.line);
 	eattok(parser, T_CONST);
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_len;
+	size_t name_len = parser->lex.val_cap;
 	size_t line = parser->lex.line;
 	if (matcheattok(parser, T_FN)) {
 		size_t line = parser->lex.line;
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_len;
+		size_t name_len = parser->lex.val_cap;
 		eattok(parser, T_ID);
 		eattok(parser, T_LPAR);
 		struct Node *block = parse_function_params(parser);
@@ -279,7 +279,7 @@ static struct Node *parse_decl(struct Parser *const parser) {
 	do {
 		eattok(parser, T_LET);
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_len;
+		size_t name_len = parser->lex.val_cap;
 		size_t line = parser->lex.line;
 		eattok(parser, T_ID);
 		body_append(&buffer, new_Let(name, name_len, NULL, line));
@@ -301,7 +301,7 @@ static struct Node *parse_let(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("parsing let in line %" PRI_SIZET "\n", parser->lex.line);
 	eattok(parser, T_LET);
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_len;
+	size_t name_len = parser->lex.val_cap;
 	size_t line = parser->lex.line;
 	eattok(parser, T_ID);
 	eattok(parser, T_EQ);
@@ -314,7 +314,7 @@ static struct Node *parse_let_iterate_or_let(struct Parser *const parser) {
 		return parse_let(parser);
 	} else {
 		char *name = parser->lex.value;
-		size_t name_len = parser->lex.val_len;
+		size_t name_len = parser->lex.val_cap;
 		size_t line = parser->lex.line;
 		eattok(parser, T_ID);
 		eattok(parser, T_LEFT_ARR);
@@ -577,7 +577,7 @@ static struct Node *parse_call(struct Parser *const parser) {
 static struct Node *parse_constant(struct Parser *const parser) {
 	switch (curtok(parser)) {
 	case T_DOT:eattok(parser, T_DOT); {
-		struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
+		struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
 		eattok(parser, T_ID);
 		return cur_node;
 	  }
@@ -618,7 +618,7 @@ static struct Node *parse_constant(struct Parser *const parser) {
 
 static struct Node *parse_id(struct Parser *const parser) {
 	char *name = parser->lex.value;
-	size_t name_len = parser->lex.val_len;
+	size_t name_len = parser->lex.val_cap;
 	size_t line = parser->lex.line;
 	eattok(parser, T_ID);
 	YASL_PARSE_DEBUG_LOG("%s\n", "Parsing variable");
@@ -675,7 +675,7 @@ static struct Node *parse_boolean(struct Parser *const parser) {
 
 static struct Node *parse_string(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("%s\n", "Parsing str");
-	struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
+	struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
 
 	while (parser->lex.mode == L_INTERP) {
 		eattok(parser, T_STR);
@@ -692,12 +692,12 @@ static struct Node *parse_string(struct Parser *const parser) {
 			node_del(cur_node);
 			return handle_error(parser);
 		}
-		int result = lex_eatinterpstringbody(&parser->lex);
-		if (result) {
+		lex_eatinterpstringbody(&parser->lex);
+		if (parser->lex.status) {
 			node_del(cur_node);
 			return handle_error(parser);
 		};
-		struct Node *str = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
+		struct Node *str = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
 		cur_node = new_BinOp(T_TILDE, cur_node, str, parser->lex.line);
 	}
 

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -675,7 +675,7 @@ static struct Node *parse_boolean(struct Parser *const parser) {
 
 static struct Node *parse_string(struct Parser *const parser) {
 	YASL_PARSE_DEBUG_LOG("%s\n", "Parsing str");
-	struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
+	struct Node *cur_node = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
 
 	while (parser->lex.mode == L_INTERP) {
 		eattok(parser, T_STR);
@@ -697,7 +697,7 @@ static struct Node *parse_string(struct Parser *const parser) {
 			node_del(cur_node);
 			return handle_error(parser);
 		};
-		struct Node *str = new_String(parser->lex.value, parser->lex.val_cap, parser->lex.line);
+		struct Node *str = new_String(parser->lex.value, parser->lex.val_len, parser->lex.line);
 		cur_node = new_BinOp(T_TILDE, cur_node, str, parser->lex.line);
 	}
 

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -3,8 +3,8 @@
 #include <inttypes.h>
 
 #include "compiler/ast.h"
-#include "compiler/lexer.h"
 #include "compiler/middleend.h"
+#include "debug.h"
 #include "yasl_conf.h"
 #include "yasl_error.h"
 #include "yasl_include.h"

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "compiler/lexer.h"
-// #include "debug.h"
+#include "lexer.h"
 
 #define T1(p, a) (curtok(p) == a)
 #define T2(p, a, b) T1(p, a) || T1(p, b)

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "compiler/lexer.h"
-#include "compiler/ast.h"
-#include "debug.h"
+// #include "debug.h"
 
 #define T1(p, a) (curtok(p) == a)
 #define T2(p, a, b) T1(p, a) || T1(p, b)

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 #include "yasl_state.h"
 
 
-#define VERSION "v0.6.5"
+#define VERSION "v0.6.6"
 #define VERSION_PRINTOUT "YASL " VERSION
 
 static int load_libs(struct YASL_State *S) {

--- a/std-collections/yasl-std-collections.c
+++ b/std-collections/yasl-std-collections.c
@@ -46,14 +46,10 @@ static int YASL_collections_table_new(struct YASL_State *S) {
 }
 
 static int YASL_collections_set_tostr(struct YASL_State *S) {
-	struct YASL_Object *set_obj = YASL_popobject(S);
-
-	struct YASL_Set *set;
-	if (YASL_isuserdata(set_obj, T_SET) == YASL_SUCCESS) {
-		set = (struct YASL_Set *)YASL_UserData_getdata(set_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *set = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	size_t string_count = 0;
 	size_t string_size = 8;
@@ -94,23 +90,15 @@ static int YASL_collections_set_tostr(struct YASL_State *S) {
 
 #define YASL_COLLECTIONS_SET_BINOP(name, fn) \
 static int YASL_collections_set_##name(struct YASL_State *S) {\
-	struct YASL_Object *right_obj = YASL_popobject(S);\
-\
-	struct YASL_Set *right;\
-	if (YASL_isuserdata(right_obj, T_SET) == YASL_SUCCESS) {\
-		right = (struct YASL_Set *)YASL_UserData_getdata(right_obj);\
-	} else {\
+	if (!YASL_top_isuserdata(S, T_SET)) {\
 		return YASL_TYPE_ERROR;\
 	}\
+	struct YASL_Set *right = (struct YASL_Set *)YASL_top_popuserdata(S);\
 \
-	struct YASL_Object *left_obj = YASL_popobject(S);\
-\
-	struct YASL_Set *left;\
-	if (YASL_isuserdata(left_obj, T_SET) == YASL_SUCCESS) {\
-		left = (struct YASL_Set *)YASL_UserData_getdata(left_obj);\
-	} else {\
+	if (!YASL_top_isuserdata(S, T_SET)) {\
 		return YASL_TYPE_ERROR;\
 	}\
+	struct YASL_Set *left = (struct YASL_Set *)YASL_top_popuserdata(S);\
 \
 	struct YASL_Set *tmp = fn(left, right);\
 \
@@ -124,14 +112,10 @@ YASL_COLLECTIONS_SET_BINOP(__bxor, YASL_Set_symmetric_difference)
 YASL_COLLECTIONS_SET_BINOP(__sub, YASL_Set_difference)
 
 static int YASL_collections_set___len(struct YASL_State *S) {
-	struct YASL_Object *set_obj = YASL_popobject(S);
-
-	struct YASL_Set *set;
-	if (YASL_isuserdata(set_obj, T_SET) == YASL_SUCCESS) {
-		set = (struct YASL_Set *)YASL_UserData_getdata(set_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *set = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	YASL_pushinteger(S, YASL_Set_length(set));
 	return YASL_SUCCESS;
@@ -145,14 +129,10 @@ static int YASL_collections_set_add(struct YASL_State *S) {
 		printf("Error: unable to insert mutable object of type %x into set.\n", right_obj->type);
 		return YASL_TYPE_ERROR;
 	}
-	struct YASL_Object left_obj = vm_peek((struct VM *)S);
-
-	struct YASL_Set *left;
-	if (YASL_isuserdata(&left_obj, T_SET) == YASL_SUCCESS) {
-		left = (struct YASL_Set *)YASL_UserData_getdata(&left_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *left = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	YASL_Set_insert(left, *right_obj);
 
@@ -167,14 +147,10 @@ static int YASL_collections_set_remove(struct YASL_State *S) {
 		printf("Error: unable to remove mutable object of type %x into set.\n", right_obj.type);
 		return YASL_TYPE_ERROR;
 	}
-	struct YASL_Object left_obj = vm_pop((struct VM *)S);
-
-	struct YASL_Set *left;
-	if (YASL_isuserdata(&left_obj, T_SET) == YASL_SUCCESS) {
-		left = (struct YASL_Set *)YASL_UserData_getdata(&left_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *left = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	YASL_Set_rm(left, right_obj);
 
@@ -183,13 +159,10 @@ static int YASL_collections_set_remove(struct YASL_State *S) {
 }
 
 static int YASL_collections_set_copy(struct YASL_State *S) {
-	struct YASL_Object *set_obj = YASL_popobject(S);
-	struct YASL_Set *set;
-	if (YASL_isuserdata(set_obj, T_SET) == YASL_SUCCESS) {
-		set = (struct YASL_Set *)YASL_UserData_getdata(set_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *set = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	struct YASL_Set *tmp = YASL_Set_new();
 	FOR_SET(i, item, set) {
@@ -201,13 +174,10 @@ static int YASL_collections_set_copy(struct YASL_State *S) {
 }
 
 static int YASL_collections_set_clear(struct YASL_State *S) {
-	struct YASL_Object set_obj = vm_peek((struct VM *)S);
-	struct YASL_Set *set;
-	if (YASL_isuserdata(&set_obj, T_SET) == YASL_SUCCESS) {
-		set = (struct YASL_Set *)YASL_UserData_getdata(&set_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *set = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	FOR_SET(i, item, set) {
 			YASL_Set_rm(set, *item);
@@ -218,13 +188,10 @@ static int YASL_collections_set_clear(struct YASL_State *S) {
 
 static int YASL_collections_set_contains(struct YASL_State *S) {
 	struct YASL_Object *object = YASL_popobject(S);
-	struct YASL_Object *set_obj = YASL_popobject(S);
-	struct YASL_Set *set;
-	if (YASL_isuserdata(set_obj, T_SET) == YASL_SUCCESS) {
-		set = (struct YASL_Set *)YASL_UserData_getdata(set_obj);
-	} else {
+	if (!YASL_top_isuserdata(S, T_SET)) {
 		return YASL_TYPE_ERROR;
 	}
+	struct YASL_Set *set = (struct YASL_Set *)YASL_top_popuserdata(S);
 
 	vm_push((struct VM *)S, YASL_Set_search(set, *object));
 	return YASL_SUCCESS;

--- a/std-collections/yasl-std-collections.c
+++ b/std-collections/yasl-std-collections.c
@@ -213,28 +213,25 @@ int YASL_load_collections(struct YASL_State *S) {
 		YASL_Table_insert_literalcstring_cfunction(set_mt, "contains", YASL_collections_set_contains, 2);
 	}
 
-	struct YASL_Object *collections = YASL_Table();
 	YASL_declglobal(S, "collections");
-	YASL_pushobject(S, collections);
+	YASL_pushtable(S);
+	YASL_setglobal(S, "collections");
 
-	YASL_pushobject(S, collections);
+	YASL_loadglobal(S, "collections");
 	YASL_pushlitszstring(S, "set");
 	YASL_pushcfunction(S, YASL_collections_set_new, -1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, collections);
+	YASL_loadglobal(S, "collections");
 	YASL_pushlitszstring(S, "list");
 	YASL_pushcfunction(S, YASL_collections_list_new, -1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, collections);
+	YASL_loadglobal(S, "collections");
 	YASL_pushlitszstring(S, "table");
 	YASL_pushcfunction(S, YASL_collections_table_new, -1);
 	YASL_settable(S);
 
-	YASL_setglobal(S, "collections");
-
-	free(collections);
 	return YASL_SUCCESS;
 }
 

--- a/std-io/yasl-std-io.c
+++ b/std-io/yasl-std-io.c
@@ -181,48 +181,44 @@ int YASL_load_io(struct YASL_State *S) {
 				  YASL_CFN(YASL_io_flush, 1));
 	}
 
-	struct YASL_Object *io = YASL_Table();
 	YASL_declglobal(S, "io");
-	YASL_pushobject(S, io);
+	YASL_pushtable(S);
+	YASL_setglobal(S, "io");
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "open");
 	YASL_pushcfunction(S, YASL_io_open, 2);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "read");
 	YASL_pushcfunction(S, YASL_io_read, 2);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "write");
 	YASL_pushcfunction(S, YASL_io_write, 2);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "flush");
 	YASL_pushcfunction(S, YASL_io_flush, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "stdin");
 	YASL_pushuserdata(S, stdin, T_FILE, mt, NULL);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "stdout");
 	YASL_pushuserdata(S, stdout, T_FILE, mt, NULL);
 	YASL_settable(S);
 
-	YASL_pushobject(S, io);
+	YASL_loadglobal(S, "io");
 	YASL_pushlitszstring(S, "stderr");
 	YASL_pushuserdata(S, stderr, T_FILE, mt, NULL);
 	YASL_settable(S);
-
-	YASL_setglobal(S, "io");
-
-	free(io);
 
 	return YASL_SUCCESS;
 }

--- a/std-io/yasl-std-io.c
+++ b/std-io/yasl-std-io.c
@@ -90,14 +90,10 @@ static int YASL_io_read(struct YASL_State *S) {
 	}
 	YASL_popobject(S);
 
-	struct YASL_Object *file = YASL_popobject(S);
-	FILE *f;
-
-	if (YASL_isuserdata(file, T_FILE) == YASL_SUCCESS) {
-		f = (FILE *)YASL_UserData_getdata(file);
-	} else {
+	if (!YASL_top_isuserdata(S, T_FILE)) {
 		return YASL_TYPE_ERROR;
 	}
+	FILE *f = (FILE *)YASL_top_popuserdata(S);
 
 	size_t mode_len = strlen(mode_str);
 
@@ -147,14 +143,10 @@ static int YASL_io_write(struct YASL_State *S) {
 	char *str = YASL_top_peekcstring(S);
 	YASL_popobject(S);
 
-	struct YASL_Object *file = YASL_popobject(S);
-	FILE *f;
-
-	if (YASL_isuserdata(file, T_FILE) == YASL_SUCCESS) {
-		f = (FILE *)YASL_UserData_getdata(file);
-	} else {
+	if (!YASL_top_isuserdata(S, T_FILE)) {
 		return YASL_TYPE_ERROR;
 	}
+	FILE *f = (FILE *)YASL_top_popuserdata(S);
 
 	size_t len = strlen(str);
 
@@ -166,14 +158,10 @@ static int YASL_io_write(struct YASL_State *S) {
 }
 
 static int YASL_io_flush(struct YASL_State *S) {
-	struct YASL_Object *file = YASL_popobject(S);
-	FILE *f;
-
-	if (YASL_isuserdata(file, T_FILE) == YASL_SUCCESS) {
-		f = (FILE *)YASL_UserData_getdata(file);
-	} else {
+	if (!YASL_top_isuserdata(S, T_FILE)) {
 		return YASL_TYPE_ERROR;
 	}
+	FILE *f = (FILE *)YASL_top_popuserdata(S);
 
 	int success = fflush(f);
 

--- a/std-math/yasl-std-math.c
+++ b/std-math/yasl-std-math.c
@@ -342,128 +342,124 @@ static int YASL_math_rand(struct YASL_State *S) {
 }
 
 int YASL_load_math(struct YASL_State *S) {
-	struct YASL_Object *math = YASL_Table();
 	YASL_declglobal(S, "math");
-	YASL_pushobject(S, math);
+	YASL_pushtable(S);
+	YASL_setglobal(S, "math");
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "abs");
 	YASL_pushcfunction(S, YASL_math_abs, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "exp");
 	YASL_pushcfunction(S, YASL_math_exp, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "log");
 	YASL_pushcfunction(S, YASL_math_log, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "pi");
 	YASL_pushfloat(S, YASL_PI);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "nan");
 	YASL_pushfloat(S, YASL_NAN);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "inf");
 	YASL_pushfloat(S, YASL_INF);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "sqrt");
 	YASL_pushcfunction(S, YASL_math_sqrt, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "cos");
 	YASL_pushcfunction(S, YASL_math_cos, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "sin");
 	YASL_pushcfunction(S, YASL_math_sin, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "tan");
 	YASL_pushcfunction(S, YASL_math_tan, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "acos");
 	YASL_pushcfunction(S, YASL_math_acos, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "asin");
 	YASL_pushcfunction(S, YASL_math_asin, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "atan");
 	YASL_pushcfunction(S, YASL_math_atan, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "ceil");
 	YASL_pushcfunction(S, YASL_math_ceil, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "floor");
 	YASL_pushcfunction(S, YASL_math_floor, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "max");
 	YASL_pushcfunction(S, YASL_math_max, -1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "min");
 	YASL_pushcfunction(S, YASL_math_min, -1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "deg");
 	YASL_pushcfunction(S, YASL_math_deg, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "rad");
 	YASL_pushcfunction(S, YASL_math_rad, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "isprime");
 	YASL_pushcfunction(S, YASL_math_isprime, 1);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "gcd");
 	YASL_pushcfunction(S, YASL_math_gcd, 2);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "lcm");
 	YASL_pushcfunction(S, YASL_math_lcm, 2);
 	YASL_settable(S);
 
-	YASL_pushobject(S, math);
+	YASL_loadglobal(S, "math");
 	YASL_pushlitszstring(S, "rand");
 	YASL_pushcfunction(S, YASL_math_rand, 1);
 	YASL_settable(S);
-
-	YASL_setglobal(S, "math");
-
-	free(math);
 
 	return YASL_SUCCESS;
 }

--- a/test/clitest.c
+++ b/test/clitest.c
@@ -22,7 +22,7 @@ static const struct {
 	int line;
 	const char *args[3];
 } tests[] =
-	{{"YASL v0.6.5\n", TST, {"-V", NULL}},
+	{{"YASL v0.6.6\n", TST, {"-V", NULL}},
 	 {"10\n", TST, {"-e", "let x=10; x;", NULL}},
 	 {"", TST, {"-E", "let x=10; x;", NULL}},
 	 {"10\n", TST, {"-E", "let x=10; echo x;", NULL}},

--- a/test/unit_tests/test_compiler/syntaxerrortest.c
+++ b/test/unit_tests/test_compiler/syntaxerrortest.c
@@ -40,6 +40,7 @@ int syntaxerrortest(void) {
 	ASSERT_SYNTAX_ERR("\"asdsadasd", "Unclosed string literal in line 1");
 	ASSERT_SYNTAX_ERR("\"das#{1}asd\n", "Unclosed string literal in line 1");
 	ASSERT_SYNTAX_ERR("\"das#{1}asd", "Unclosed string literal in line 1");
+	ASSERT_SYNTAX_ERR("\"asdasd#{1 asdda\";", "Expected } in line 1");
 	ASSERT_SYNTAX_ERR("'asdsadasd\n", "Unclosed string literal in line 1");
 	ASSERT_SYNTAX_ERR("'asdsadasd", "Unclosed string literal in line 1");
 	ASSERT_SYNTAX_ERR("`asdsadasd", "Unclosed string literal in line 1");

--- a/test/yats.c
+++ b/test/yats.c
@@ -1,11 +1,11 @@
 #include "yats.h"
 
-#include "yasl.h"
 #include "compiler/ast.h"
-#include "compiler/parser.h"
 #include "compiler/compiler.h"
-#include "test/unit_tests/test_compiler/compilertest.h"
 #include "compiler/lexinput.h"
+#include "compiler/parser.h"
+#include "test/unit_tests/test_compiler/compilertest.h"
+#include "yasl.h"
 
 struct Lexer setup_lexer(const char *file_contents) {
 	FILE *fptr = fopen("dump.ysl", "w");

--- a/test/yats.h
+++ b/test/yats.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "compiler/lexer.h"

--- a/yasl.c
+++ b/yasl.c
@@ -281,6 +281,13 @@ int YASL_pushcfunction(struct YASL_State *S, int (*value)(struct YASL_State *), 
 	return YASL_SUCCESS;
 }
 
+int YASL_pushtable(struct YASL_State *S) {
+	struct YASL_Object *table = YASL_Table();
+	vm_push(&S->vm, *table);
+	free(table);
+	return YASL_SUCCESS;
+}
+
 int YASL_pushobject(struct YASL_State *S, struct YASL_Object *obj) {
 	if (!obj) return YASL_ERROR;
 	vm_push((struct VM *) S, *obj);

--- a/yasl.c
+++ b/yasl.c
@@ -416,8 +416,16 @@ int YASL_isuserdata(struct YASL_Object *obj, int tag) {
 	return YASL_ERROR;
 }
 
+bool YASL_top_isuserdata(struct YASL_State *S, int tag) {
+	return YASL_ISUSERDATA(vm_peek(&S->vm)) && vm_peek(&S->vm).value.uval->tag == tag;
+}
+
 int YASL_isuserpointer(struct YASL_Object *obj) {
 	return obj->type == Y_USERPTR ? YASL_SUCCESS : YASL_ERROR;
+}
+
+bool YASL_top_isuserpointer(struct YASL_State *S) {
+	return YASL_ISUSERPTR(vm_peek(&S->vm));
 }
 
 bool YASL_getboolean(struct YASL_Object *obj) {
@@ -512,10 +520,6 @@ char *YASL_getstring(struct YASL_Object *obj) {
 	return obj->value.sval->str + obj->value.sval->start;
 }
 
-
-// int (*)(struct YASL_State) *YASL_getcfunction(struct YASL_Object *obj);
-
-
 void *YASL_getuserdata(struct YASL_Object *obj) {
 	if (obj->type == Y_USERDATA || obj->type == Y_USERDATA_W) {
 		return obj->value.uval->data;
@@ -523,6 +527,13 @@ void *YASL_getuserdata(struct YASL_Object *obj) {
 	return NULL;
 }
 
+void *YASL_top_peekuserdata(struct YASL_State *S) {
+	return YASL_GETUSERDATA(vm_peek(&S->vm))->data;
+}
+
+void *YASL_top_popuserdata(struct YASL_State *S) {
+	return YASL_GETUSERDATA(vm_pop(&S->vm))->data;
+}
 
 void *YASL_getuserpointer(struct YASL_Object *obj) {
 	if (obj->type != Y_USERPTR) {
@@ -531,3 +542,10 @@ void *YASL_getuserpointer(struct YASL_Object *obj) {
 	return obj->value.pval;
 }
 
+void *YASL_top_peekuserpointer(struct YASL_State *S) {
+	return YASL_GETUSERPTR(vm_peek(&S->vm));
+}
+
+void *YASL_top_popuserpointer(struct YASL_State *S) {
+	return YASL_GETUSERPTR(vm_pop(&S->vm));
+}

--- a/yasl.c
+++ b/yasl.c
@@ -203,6 +203,7 @@ struct YASL_Object *YASL_getglobal(struct YASL_State *S, const char *name) {
 int YASL_loadglobal(struct YASL_State *S, const char *name) {
 	struct YASL_String *string = YASL_String_new_sized(strlen(name), name);
 	struct YASL_Object global = YASL_Table_search(S->vm.globals[0], YASL_STR(string));
+	str_del(string);
 	if (global.type == Y_END) {
 		return YASL_ERROR;
 	}

--- a/yasl.h
+++ b/yasl.h
@@ -148,6 +148,14 @@ int YASL_pushstring(struct YASL_State *S, const char *value, const size_t size);
 int YASL_pushlitstring(struct YASL_State *S, const char *value, const size_t size);
 
 /**
+ * Pushes an empty table onto the stack.
+ * @param S the YASL_State onto which to push the table.
+ * @return 0 on success, else error code.
+ */
+int YASL_pushtable(struct YASL_State *S);
+
+
+/**
  * Pushes a function pointer onto the stack
  * @param S the YASL_State onto which to push the string.
  * @param value the function pointer to be pushed onto the stack.
@@ -177,6 +185,7 @@ int YASL_pushuserpointer(struct YASL_State *S, void *userpointer);
  * @param obj the YASL_Object to push onto the stack.
  * @return 0 on succes, else error code.
  */
+// YASL_DEPRECATE
 int YASL_pushobject(struct YASL_State *S, struct YASL_Object *obj);
 
 /**
@@ -184,6 +193,7 @@ int YASL_pushobject(struct YASL_State *S, struct YASL_Object *obj);
  * @param S the YASL_State from which to pop the YASL_Object.
  * @return a YASL_Object* on succes, else NULL.
  */
+// YASL_DEPRECATE
 struct YASL_Object *YASL_popobject(struct YASL_State *S);
 
 YASL_DEPRECATE

--- a/yasl.h
+++ b/yasl.h
@@ -336,7 +336,7 @@ int YASL_iscfunction(struct YASL_Object *obj);
  * @param obj the given YASL_Object.
  * @return true if the given YASL_Object is userdata, else false.
  */
-// YASL_DEPRECATE
+YASL_DEPRECATE
 int YASL_isuserdata(struct YASL_Object *obj, int tag);
 
 bool YASL_top_isuserdata(struct YASL_State *S, int tag);
@@ -346,7 +346,10 @@ bool YASL_top_isuserdata(struct YASL_State *S, int tag);
  * @param obj the given YASL_Object.
  * @return true if the given YASL_Object is userpointer, else false.
  */
+YASL_DEPRECATE
 int YASL_isuserpointer(struct YASL_Object *obj);
+
+bool YASL_top_isuserpointer(struct YASL_State *S);
 
 /**
  * Retrieves the boolean value of the YASL_Object.
@@ -409,6 +412,9 @@ char *YASL_getstring(struct YASL_Object *obj);
 YASL_DEPRECATE
 void *YASL_getuserdata(struct YASL_Object *obj);
 
+void *YASL_top_peekuserdata(struct YASL_State *S);
+void *YASL_top_popuserdata(struct YASL_State *S);
+
 /**
  * Retrieves the userpointer value of the YASL_Object.
  * @param obj the given YASL_Object.
@@ -416,3 +422,6 @@ void *YASL_getuserdata(struct YASL_Object *obj);
  */
 YASL_DEPRECATE
 void *YASL_getuserpointer(struct YASL_Object *obj);
+
+void *YASL_top_peekuserpointer(struct YASL_State *S);
+void *YASL_top_popuserpointer(struct YASL_State *S);

--- a/yasl_include.h
+++ b/yasl_include.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 


### PR DESCRIPTION
New Features:
- C API now has functions to deal with user-pointers and user-data under new API.

Deprecations:
- Deprecated most functions that use `YASL_Object`.

Bug Fixes:
- Fixed one of the error messages for malformed interpolated strings.
- YASL_(String) functions used to incorrectly return NULL.

Internal Changes:
- cleaned up lexer implementation.
- cleaned up parser implementation.