### PR TITLE
Disallow mutable hash table keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,10 @@ if(MSVC)
 endif()
 
 if (NOT "${CMAKE_C_COMPILER_ID}" MATCHES ".*MSVC.*")
-    set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-vla -Wpedantic -Werror")
+    set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-vla -Wpedantic -Werror")
 endif()
 if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES ".*MSVC.*")
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-unused-variable -Wno-vla -Wno-deprecated -Werror")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-variable -Wno-vla -Wno-deprecated -Werror")
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,10 @@ if(MSVC)
 endif()
 
 if (NOT "${CMAKE_C_COMPILER_ID}" MATCHES ".*MSVC.*")
-    set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-unused-parameter -Wno-vla -Wpedantic -Werror")
+    set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-vla -Wpedantic -Werror")
 endif()
 if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES ".*MSVC.*")
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-unused-variable -Wno-unused-parameter -Wno-vla -Wno-deprecated -Werror")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Wno-unused-result -Wno-unused-variable -Wno-vla -Wno-deprecated -Werror")
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -1002,6 +1002,7 @@ static void visit_Var(struct Compiler *const compiler, const struct Node *const 
 }
 
 static void visit_Undef(struct Compiler *const compiler, const struct Node *const node) {
+	(void) node;
 	YASL_ByteBuffer_add_byte(compiler->buffer, O_NCONST);
 }
 

--- a/compiler/env.c
+++ b/compiler/env.c
@@ -83,10 +83,10 @@ int64_t env_get(const struct Env *const env, const char *const name) {
 
 int64_t env_decl_var(struct Env *const env, const char *const name) {
 	const size_t name_len = strlen(name);
-	// struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
-	// struct YASL_Object key = YASL_STR(string);
-	// struct YASL_Object value = YASL_INT((long)env_len(env));
-	YASL_Table_insert_string_int(&env->vars, copy_char_buffer(name_len, name), name_len, env_len(env));
+	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
+	struct YASL_Object key = YASL_STR(string);
+	struct YASL_Object value = YASL_INT((long)env_len(env));
+	YASL_Table_insert_fast(&env->vars, key, value);
 	return env_len(env);
 }
 

--- a/compiler/env.c
+++ b/compiler/env.c
@@ -83,10 +83,10 @@ int64_t env_get(const struct Env *const env, const char *const name) {
 
 int64_t env_decl_var(struct Env *const env, const char *const name) {
 	const size_t name_len = strlen(name);
-	struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
-	struct YASL_Object key = YASL_STR(string);
-	struct YASL_Object value = YASL_INT((long)env_len(env));
-	YASL_Table_insert(&env->vars, key, value);
+	// struct YASL_String *string = YASL_String_new_sized_heap(0, name_len, copy_char_buffer(name_len, name));
+	// struct YASL_Object key = YASL_STR(string);
+	// struct YASL_Object value = YASL_INT((long)env_len(env));
+	YASL_Table_insert_string_int(&env->vars, copy_char_buffer(name_len, name), name_len, env_len(env));
 	return env_len(env);
 }
 

--- a/data-structures/YASL_Table.c
+++ b/data-structures/YASL_Table.c
@@ -8,6 +8,7 @@
 #include "interpreter/refcount.h"
 #include "interpreter/YASL_Object.h"
 #include "interpreter/userdata.h"
+#include "yasl_error.h"
 
 struct YASL_Table_Item TOMBSTONE = { { Y_END, { Y_END } }, { Y_END, { Y_END } } };
 
@@ -123,6 +124,14 @@ void YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object 
 	}
 	table->items[index] = item;
 	table->count++;
+}
+
+int YASL_Table_insert_slow(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) {
+	if (!ishashable(key)) {
+		return YASL_TYPE_ERROR;
+	}
+	YASL_Table_insert(table, key, value);
+	return YASL_SUCCESS;
 }
 
 void YASL_Table_insert_string_int(struct YASL_Table *const table, const char *const key, const size_t key_len,

--- a/data-structures/YASL_Table.c
+++ b/data-structures/YASL_Table.c
@@ -78,7 +78,7 @@ static void table_resize(struct YASL_Table *const table, const size_t base_size)
 	if (base_size < TABLE_BASESIZE) return;
 	struct YASL_Table *new_table = table_new_sized(base_size);
 	FOR_TABLE(i, item, table) {
-			YASL_Table_insert(new_table, item->key, item->value);
+			YASL_Table_insert_fast(new_table, item->key, item->value);
 	}
 	table->base_size = new_table->base_size;
 	table->count = new_table->count;
@@ -104,7 +104,7 @@ static void table_resize_down(struct YASL_Table *const table) {
 	table_resize(table, new_size);
 }
 
-void YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) {
+void YASL_Table_insert_fast(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) {
 	const size_t load = table->count * 100 / table->size;
 	if (load > 70) table_resize_up(table);
 	struct YASL_Table_Item item = new_item(key, value);
@@ -126,12 +126,12 @@ void YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object 
 	table->count++;
 }
 
-int YASL_Table_insert_slow(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) {
+bool YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) {
 	if (!ishashable(key)) {
-		return YASL_TYPE_ERROR;
+		return false;
 	}
-	YASL_Table_insert(table, key, value);
-	return YASL_SUCCESS;
+	YASL_Table_insert_fast(table, key, value);
+	return true;
 }
 
 void YASL_Table_insert_string_int(struct YASL_Table *const table, const char *const key, const size_t key_len,
@@ -139,7 +139,7 @@ void YASL_Table_insert_string_int(struct YASL_Table *const table, const char *co
 	struct YASL_String *string = YASL_String_new_sized_heap(0, key_len, copy_char_buffer(key_len, key));
 	struct YASL_Object ko = YASL_STR(string);
 	struct YASL_Object vo = YASL_INT(val);
-	YASL_Table_insert(table, ko, vo);
+	YASL_Table_insert_fast(table, ko, vo);
 }
 
 void YASL_Table_insert_literalcstring_cfunction(struct YASL_Table *const ht, const char *key,
@@ -147,7 +147,7 @@ void YASL_Table_insert_literalcstring_cfunction(struct YASL_Table *const ht, con
 	struct YASL_String *string = YASL_String_new_sized(strlen(key), key);
 	struct YASL_Object f = YASL_CFN(addr, num_args);
 	struct YASL_Object s = YASL_STR(string);
-	YASL_Table_insert(ht, s, f);
+	YASL_Table_insert_fast(ht, s, f);
 }
 
 struct YASL_Object YASL_Table_search(const struct YASL_Table *const table, const struct YASL_Object key) {

--- a/data-structures/YASL_Table.h
+++ b/data-structures/YASL_Table.h
@@ -35,6 +35,7 @@ void del_item(struct YASL_Table_Item *const item);
 
 struct YASL_Table *YASL_Table_new(void);
 void YASL_Table_del(struct YASL_Table *const table);
+int YASL_Table_insert_slow(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) YASL_WARN_UNUSED;
 void YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value);
 void YASL_Table_insert_string_int(struct YASL_Table *const table, const char *const key, const size_t key_len,
 				  const int64_t val);

--- a/data-structures/YASL_Table.h
+++ b/data-structures/YASL_Table.h
@@ -3,6 +3,7 @@
 
 #include "interpreter/YASL_Object.h"
 #include "util/prime.h"
+#include "yasl_include.h"
 
 #define TABLE_BASESIZE 30
 

--- a/data-structures/YASL_Table.h
+++ b/data-structures/YASL_Table.h
@@ -36,8 +36,8 @@ void del_item(struct YASL_Table_Item *const item);
 
 struct YASL_Table *YASL_Table_new(void);
 void YASL_Table_del(struct YASL_Table *const table);
-int YASL_Table_insert_slow(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) YASL_WARN_UNUSED;
-void YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value);
+bool YASL_Table_insert(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value) YASL_WARN_UNUSED;
+void YASL_Table_insert_fast(struct YASL_Table *const table, const struct YASL_Object key, const struct YASL_Object value);
 void YASL_Table_insert_string_int(struct YASL_Table *const table, const char *const key, const size_t key_len,
 				  const int64_t val);
 void YASL_Table_insert_literalcstring_cfunction(struct YASL_Table *const ht, const char *key,

--- a/interpreter/VM.c
+++ b/interpreter/VM.c
@@ -691,7 +691,7 @@ static int vm_GSTORE_8(struct VM *const vm) {
 	addr += sizeof(yasl_int);
 	struct YASL_String *string = YASL_String_new_sized(size, ((char *) vm->headers[table]) + addr);
 
-	YASL_Table_insert(vm->globals[table], YASL_STR(string), vm_pop(vm));
+	YASL_Table_insert_fast(vm->globals[table], YASL_STR(string), vm_pop(vm));
 	return YASL_SUCCESS;
 }
 
@@ -1036,7 +1036,7 @@ int vm_run(struct VM *const vm) {
 			while (vm_peek(vm).type != Y_END) {
 				struct YASL_Object val = vm_pop(vm);
 				struct YASL_Object key = vm_pop(vm);
-				if (YASL_Table_insert_slow(ht, key, val) != YASL_SUCCESS) {
+				if (!YASL_Table_insert(ht, key, val)) {
 					vm_print_err_type(vm, "unable to use mutable object of type %s as key.\n", YASL_TYPE_NAMES[key.type]);
 					return YASL_TYPE_ERROR;
 				}

--- a/interpreter/VM.c
+++ b/interpreter/VM.c
@@ -716,6 +716,7 @@ static int vm_GLOAD_8(struct VM *const vm) {
 }
 
 void vm_CLOSE(struct VM *const vm) {
+	(void) vm;
 	// TODO
 }
 

--- a/interpreter/YASL_Object.c
+++ b/interpreter/YASL_Object.c
@@ -80,6 +80,17 @@ int yasl_object_cmp(struct YASL_Object a, struct YASL_Object b) {
 	return 0;
 }
 
+bool ishashable(struct YASL_Object v) {
+	return (
+		YASL_ISUNDEF(v) ||
+		YASL_ISBOOL(v) ||
+		YASL_ISFLOAT(v) ||
+		YASL_ISINT(v) ||
+		YASL_ISSTR(v) ||
+		YASL_ISUSERPTR(v)
+		);
+}
+
 bool isfalsey(struct YASL_Object v) {
 	/*
 	 * Falsey values are:

--- a/interpreter/YASL_Object.c
+++ b/interpreter/YASL_Object.c
@@ -39,6 +39,7 @@ struct CFunction *new_cfn(int (*value)(struct YASL_State *), int num_args) {
 }
 
 void cfn_del_data(struct CFunction *cfn) {
+	(void) cfn;
 }
 
 void cfn_del_rc(struct CFunction *cfn) {
@@ -79,7 +80,7 @@ int yasl_object_cmp(struct YASL_Object a, struct YASL_Object b) {
 	return 0;
 }
 
-int isfalsey(struct YASL_Object v) {
+bool isfalsey(struct YASL_Object v) {
 	/*
 	 * Falsey values are:
 	 * 	undef

--- a/interpreter/YASL_Object.h
+++ b/interpreter/YASL_Object.h
@@ -91,7 +91,8 @@ struct YASL_Object *YASL_CFunction(int (*value)(struct YASL_State *), int num_ar
  */
 int yasl_object_cmp(struct YASL_Object a, struct YASL_Object b);
 
-int isfalsey(struct YASL_Object v);
+bool ishashable(struct YASL_Object v);
+bool isfalsey(struct YASL_Object v);
 struct YASL_Object isequal(struct YASL_Object a, struct YASL_Object b);
 int print(struct YASL_Object a);
 

--- a/interpreter/builtins.c
+++ b/interpreter/builtins.c
@@ -21,7 +21,7 @@
 void table_insert_specialstring_cfunction(struct VM *vm, struct YASL_Table *ht, int index, int (*addr)(struct YASL_State *), int num_args) {
 	struct YASL_String *string = vm->special_strings[index];
 	struct YASL_Object ko = YASL_STR(string), vo = YASL_CFN(addr, num_args);
-	YASL_Table_insert(ht, ko, vo);
+	YASL_Table_insert_fast(ht, ko, vo);
 }
 
 struct YASL_Table *undef_builtins(struct VM *vm) {

--- a/interpreter/table_methods.c
+++ b/interpreter/table_methods.c
@@ -36,12 +36,11 @@ int table___set(struct YASL_State *S) {
 		YASL_Table_rm(ht, key);
 		return YASL_SUCCESS;
 	}
-	if (YASL_ISLIST(key) || YASL_ISTABLE(key) || YASL_ISUSERDATA(key)) {
-		YASL_PRINT_ERROR("Error: unable to use mutable object of type %s as key.\n", YASL_TYPE_NAMES[key.type]);
-		return -1;
+
+	if (YASL_Table_insert_slow(ht, key, val) != YASL_SUCCESS) {
+		vm_print_err_type(&S->vm, "unable to use mutable object of type %s as key.\n", YASL_TYPE_NAMES[key.type]);
+		return YASL_TYPE_ERROR;
 	}
-	YASL_Table_insert(ht, key, val);
-	//vm_push((struct VM *)S, val);
 	return YASL_SUCCESS;
 }
 

--- a/interpreter/table_methods.c
+++ b/interpreter/table_methods.c
@@ -37,7 +37,7 @@ int table___set(struct YASL_State *S) {
 		return YASL_SUCCESS;
 	}
 
-	if (YASL_Table_insert_slow(ht, key, val) != YASL_SUCCESS) {
+	if (!YASL_Table_insert(ht, key, val)) {
 		vm_print_err_type(&S->vm, "unable to use mutable object of type %s as key.\n", YASL_TYPE_NAMES[key.type]);
 		return YASL_TYPE_ERROR;
 	}
@@ -246,7 +246,7 @@ int table_clone(struct YASL_State *S) {
 	struct RC_UserData *new_ht = rcht_new_sized(ht->base_size);
 
 	FOR_TABLE(i, item, ht) {
-			YASL_Table_insert((struct YASL_Table *) new_ht->data, item->key, item->value);
+			YASL_Table_insert_fast((struct YASL_Table *) new_ht->data, item->key, item->value);
 	}
 
 	vm_push((struct VM *) S, YASL_TABLE(new_ht));

--- a/main.c
+++ b/main.c
@@ -23,6 +23,7 @@ static int load_libs(struct YASL_State *S) {
 }
 
 static int main_error(int argc, char **argv) {
+	(void) argv;
 	printf("error: Invalid arguments passed (passed %d arguments). Type `yasl -h` for help (without the backticks).\n", argc);
 	return EXIT_FAILURE;
 }
@@ -30,6 +31,8 @@ static int main_error(int argc, char **argv) {
 // -b: run bytecode
 // -c: compile to bytecode
 static int main_help(int argc, char **argv) {
+	(void) argc;
+	(void) argv;
 	puts("usage: yasl [option] [input]\n"
 	     "options:\n"
 	     "\t-C: checks `input` for syntax errors but doesn't run it.\n"
@@ -43,6 +46,8 @@ static int main_help(int argc, char **argv) {
 }
 
 static int main_version(int argc, char **argv) {
+	(void) argc;
+	(void) argv;
 	puts(VERSION_PRINTOUT);
 	return 0;
 }
@@ -72,6 +77,7 @@ static int main_file(int argc, char **argv) {
 }
 
 static int main_compile(int argc, char **argv) {
+	(void) argc;
 	struct YASL_State *S = YASL_newstate(argv[2]);
 
 	if (!S) {
@@ -90,6 +96,7 @@ static int main_compile(int argc, char **argv) {
 }
 
 static int main_command_REPL(int argc, char **argv) {
+	(void) argc;
 	const size_t size = strlen(argv[2]);
 	struct YASL_State *S = YASL_newstate_bb(argv[2], size);
 	load_libs(S);
@@ -99,6 +106,7 @@ static int main_command_REPL(int argc, char **argv) {
 }
 
 static int main_command(int argc, char **argv) {
+	(void) argc;
 	const size_t size = strlen(argv[2]);
 	struct YASL_State *S = YASL_newstate_bb(argv[2], size);
 	load_libs(S);
@@ -108,6 +116,8 @@ static int main_command(int argc, char **argv) {
 }
 
 static int main_REPL(int argc, char **argv) {
+	(void) argc;
+	(void) argv;
 	int next;
 	size_t size = 8, count = 0;
 	char *buffer = (char *)malloc(size);

--- a/std/yasl-std-collections.c
+++ b/std/yasl-std-collections.c
@@ -37,7 +37,7 @@ static int YASL_collections_table_new(struct YASL_State *S) {
 	while (i > 0) {
 		struct YASL_Object value = vm_pop((struct VM *)S);
 		struct YASL_Object key = vm_pop((struct VM *)S);
-		YASL_Table_insert((struct YASL_Table *)table->data, key, value);
+		YASL_Table_insert_fast((struct YASL_Table *) table->data, key, value);
 		i -= 2;
 	}
 	vm_pushtable((struct VM *)S, table);

--- a/std/yasl-std-io.c
+++ b/std/yasl-std-io.c
@@ -181,12 +181,12 @@ static int YASL_io_flush(struct YASL_State *S) {
 int YASL_load_io(struct YASL_State *S) {
 	if (!mt) {
 		mt = YASL_Table_new();
-		YASL_Table_insert(mt, YASL_STR(YASL_String_new_sized(strlen("read"), "read")),
-				  YASL_CFN(YASL_io_read, 2));
-		YASL_Table_insert(mt, YASL_STR(YASL_String_new_sized(strlen("write"), "write")),
-				  YASL_CFN(YASL_io_write, 2));
-		YASL_Table_insert(mt, YASL_STR(YASL_String_new_sized(strlen("flush"), "flush")),
-				  YASL_CFN(YASL_io_flush, 1));
+		YASL_Table_insert_fast(mt, YASL_STR(YASL_String_new_sized(strlen("read"), "read")),
+				       YASL_CFN(YASL_io_read, 2));
+		YASL_Table_insert_fast(mt, YASL_STR(YASL_String_new_sized(strlen("write"), "write")),
+				       YASL_CFN(YASL_io_write, 2));
+		YASL_Table_insert_fast(mt, YASL_STR(YASL_String_new_sized(strlen("flush"), "flush")),
+				       YASL_CFN(YASL_io_flush, 1));
 	}
 
 	YASL_declglobal(S, "io");

--- a/test/unit_tests/test_vm/vmtest.c
+++ b/test/unit_tests/test_vm/vmtest.c
@@ -195,6 +195,9 @@ int vmtest(void) {
 	ASSERT_DIV_BY_ZERO_ERR("echo 1 // 0;");
 	ASSERT_DIV_BY_ZERO_ERR("echo 1 % 0;");
 
+	ASSERT_TYPE_ERR("echo { []: .list };", "unable to use mutable object of type list as key");
+	ASSERT_TYPE_ERR("const x = {}; x[[]] = .list;", "unable to use mutable object of type list as key");
+
 	// math type errors
 	// ASSERT_ARG_TYPE_ERR("math.max(1, 2, .a);", "math.max", "float", "str", 2);
 	// ASSERT_ARG_TYPE_ERR("math.min(1, 2, .a);", "math.max", "float", "str", 2);

--- a/yasl.c
+++ b/yasl.c
@@ -159,7 +159,7 @@ int YASL_setglobal(struct YASL_State *S, const char *name) {
 	if (is_const(index)) return YASL_ERROR;
 
 	struct YASL_String *string = YASL_String_new_sized(strlen(name), name);
-	YASL_Table_insert(S->vm.globals[0], YASL_STR(string), vm_peek((struct VM *) S));
+	YASL_Table_insert_fast(S->vm.globals[0], YASL_STR(string), vm_peek((struct VM *) S));
 	YASL_pop(S);
 
 	return YASL_SUCCESS;
@@ -275,8 +275,11 @@ int YASL_settable(struct YASL_State *S) {
 
 	// TODO change to TYPE_ERROR
 	if (!YASL_ISTABLE(table))
-		return YASL_ERROR;
-	return YASL_Table_insert_slow(YASL_GETTABLE(table), key, value);
+		return YASL_TYPE_ERROR;
+	if (!YASL_Table_insert(YASL_GETTABLE(table), key, value)) {
+		return YASL_TYPE_ERROR;
+	}
+	return YASL_SUCCESS;
 }
 
 int YASL_appendlist(struct YASL_State *S) {

--- a/yasl.c
+++ b/yasl.c
@@ -160,7 +160,7 @@ int YASL_setglobal(struct YASL_State *S, const char *name) {
 
 	struct YASL_String *string = YASL_String_new_sized(strlen(name), name);
 	YASL_Table_insert(S->vm.globals[0], YASL_STR(string), vm_peek((struct VM *) S));
-	S->vm.sp--;
+	YASL_pop(S);
 
 	return YASL_SUCCESS;
 }
@@ -276,9 +276,7 @@ int YASL_settable(struct YASL_State *S) {
 	// TODO change to TYPE_ERROR
 	if (!YASL_ISTABLE(table))
 		return YASL_ERROR;
-	YASL_Table_insert(YASL_GETTABLE(table), key, value);
-
-	return YASL_SUCCESS;
+	return YASL_Table_insert_slow(YASL_GETTABLE(table), key, value);
 }
 
 int YASL_appendlist(struct YASL_State *S) {

--- a/yasl_include.h
+++ b/yasl_include.h
@@ -38,7 +38,7 @@
 #if defined __GNUC__ || defined __clang__
 #define YASL_WARN_UNUSED __attribute((warn_unused_result))
 #else
-#define YASYASL_WARN_UNUSED
+#define YASL_WARN_UNUSED
 #endif
 
 

--- a/yasl_include.h
+++ b/yasl_include.h
@@ -35,6 +35,13 @@
 #define K_WHT "\x1B[37m"
 #endif
 
+#if defined __GNUC__ || defined __clang__
+#define YASL_WARN_UNUSED __attribute((warn_unused_result))
+#else
+#define YASYASL_WARN_UNUSED
+#endif
+
+
 #define MSG_SYNTAX_ERROR "SyntaxError: "
 #define MSG_TYPE_ERROR "TypeError: "
 


### PR DESCRIPTION
check that keys for `table` are hashable. (Fixes long standing bug.)