### PR TITLE
Update CMake configure command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ YASL can be compiled from source with the following commands:
 ```bash
 git clone https://github.com/yasl-lang/yasl.git
 cd yasl
-cmake --configure .
+cmake .
 cmake --build .
 ```
 


### PR DESCRIPTION
The current build instruction don't work for me under arch linux. I think my CMake version is too new (3.20.1), it does work on other platforms. It seems like running `cmake .` without `--configure` is now the normal way to do it. CMake doesn't have any documentation for `--configure`, that's probably a bad sign.

Also, since we're on the topic, maybe it would be easier to move the build into a separate build directory:
```sh
mdkir -p build
cd build
cmake .
cmake --build .
```
Or something. But that's less pressing, and could be done in a shell script. :)

Have a nice day @CoffeeTableEspresso