### PR TITLE
Fix LF bug on Windows (fseek in text mode, yadda)

### DIFF
--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -773,19 +773,6 @@ const char *YASL_TOKEN_NAMES[] = {
 #undef X
 };
 
-struct Lexer *lex_new(FILE *file /* OWN */) {
-	struct Lexer *const lex = (struct Lexer *) malloc(sizeof(struct Lexer));
-	lex->line = 1;
-	lex_val_setnull(lex);
-	lex->buffer.size = 0;
-	lex->buffer.count = 0;
-	lex->file = lexinput_new_file(file);
-	lex->type = T_UNKNOWN;
-	lex->status = YASL_SUCCESS;
-	lex->mode = L_NORMAL;
-	return lex;
-}
-
 void lex_cleanup(struct Lexer *const lex) {
 	lxclose(lex->file);
 	io_cleanup(&lex->err);

--- a/yasl.c
+++ b/yasl.c
@@ -31,7 +31,7 @@ struct YASL_State *YASL_newstate_num(const char *filename, size_t num) {
 }
 
 struct YASL_State *YASL_newstate(const char *filename) {
-	FILE *fp = fopen(filename, "r");
+	FILE *fp = fopen(filename, "rb");
 	if (!fp) {
 		return NULL;  // Can't open file.
 	}


### PR DESCRIPTION
Debugging resulted in learning. Don't use `fseek()` for files opened in text mode, especially on Windows when there are line feeds.

Also removed dead code 😉