### PR TITLE
Fix printing UTF-8 read from file on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ endif()
 
 target_link_libraries(tests yaslapi)
 
-if (UNIX)
+if (NOT WIN32)
     target_link_libraries(yasl dl)
     target_link_libraries(yaslapi dl)
     target_link_libraries(tests dl)

--- a/compiler/lexinput.c
+++ b/compiler/lexinput.c
@@ -42,23 +42,23 @@ int lxeof(struct LEXINPUT *const lp) {
 	return lp->eof(lp);
 }
 
-static  int lexinput_file_getc(struct LEXINPUT *const lp) {
+static int lexinput_file_getc(struct LEXINPUT *const lp) {
 	return fgetc(lp->fp);
 }
 
-static  int lexinput_file_tell(struct LEXINPUT *const lp) {
+static int lexinput_file_tell(struct LEXINPUT *const lp) {
 	return ftell(lp->fp);
 }
 
-static  int lexinput_file_seek(struct LEXINPUT *const lp, int w, int cmd) {
+static int lexinput_file_seek(struct LEXINPUT *const lp, int w, int cmd) {
 	return fseek(lp->fp, w, cmd);
 }
 
-static  int lexinput_file_eof(struct LEXINPUT *const lp) {
+static int lexinput_file_eof(struct LEXINPUT *const lp) {
 	return feof(lp->fp);
 }
 
-static  int lexinput_file_close(struct LEXINPUT *const lp) {
+static int lexinput_file_close(struct LEXINPUT *const lp) {
 	fclose(lp->fp);
 	lp->fp = 0;
 	free(lp);
@@ -79,7 +79,7 @@ struct LEXINPUT *lexinput_new_file(FILE *const fp) {
 #include "data-structures/YASL_ByteBuffer.h"
 
 static int lexinput_bb_eof(struct LEXINPUT *const lp);
-static  int lexinput_bb_getc(struct LEXINPUT *const lp) {
+static int lexinput_bb_getc(struct LEXINPUT *const lp) {
 	if (lp->pos >= lp->bb->count) {
 		lp->iseof = true;
 		return -1;
@@ -87,11 +87,11 @@ static  int lexinput_bb_getc(struct LEXINPUT *const lp) {
 	return lp->bb->items[lp->pos++];
 }
 
-static  int lexinput_bb_tell(struct LEXINPUT *const lp) {
+static int lexinput_bb_tell(struct LEXINPUT *const lp) {
 	return (int)lp->pos;
 }
 
-static  int lexinput_bb_seek(struct LEXINPUT *const lp, int w, int cmd) {
+static int lexinput_bb_seek(struct LEXINPUT *const lp, int w, int cmd) {
 	if (cmd == 0) {
 		lp->pos = w;
 	} else if (cmd == 1) {
@@ -110,7 +110,7 @@ static int lexinput_bb_eof(struct LEXINPUT *const lp) {
 	return 0;
 }
 
-static  int lexinput_bb_close(struct LEXINPUT *const lp) {
+static int lexinput_bb_close(struct LEXINPUT *const lp) {
 	YASL_ByteBuffer_del(lp->bb);
 	lp->bb = 0;
 	free(lp);

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 
 #include "yasl.h"
 #include "yasl_aux.h"
+#include "yasl_plat.h"
 #include "yasl_state.h"
 
 #define VERSION_PRINTOUT "YASL " YASL_VERSION
@@ -13,8 +14,8 @@
                   "|  |  ||     | /    \\ |  |    \n" \
                   "|  |  ||  O  | |  __| |  |  \n" \
                   "|___  ||     | |__  | |  |__ \n" \
-		  "|     ||  |  | |    | |     |\n" \
-		  "|_____/|__|__| \\____/ |_____|\n"
+                  "|     ||  |  | |    | |     |\n" \
+                  "|_____/|__|__| \\____/ |_____|\n"
 
 // -b: run bytecode
 // -c: compile to bytecode
@@ -38,6 +39,15 @@ static int main_version(int argc, char **argv) {
 	(void) argv;
 	puts(VERSION_PRINTOUT);
 	return 0;
+}
+
+static inline void main_init_platform() {
+	// Initialize prng seed
+	srand(time(NULL));
+
+	#ifdef YASL_USE_WIN
+		SetConsoleOutputCP(CP_UTF8);
+	#endif
 }
 
 static int main_file(int argc, char **argv) {
@@ -161,8 +171,7 @@ static int main_REPL(int argc, char **argv) {
 
 #ifdef __EMSCRIPTEN__
 int main(int argc, char **argv) {
-	// Initialize prng seed
-	srand(time(NULL));
+	main_init_platform();
 
 	if (argc == 1) {
 		puts(VERSION_PRINTOUT);
@@ -172,8 +181,7 @@ int main(int argc, char **argv) {
 }
 #else
 int main(int argc, char **argv) {
-	// Initialize prng seed
-	srand((unsigned)time(NULL));
+	main_init_platform();
 
 	if (argc == 1) {
 		return main_REPL(argc, argv);
@@ -192,4 +200,3 @@ int main(int argc, char **argv) {
 	}
 }
 #endif
-

--- a/yasl.c
+++ b/yasl.c
@@ -11,7 +11,7 @@
 #include "compiler/lexinput.h"
 
 struct YASL_State *YASL_newstate_num(const char *filename, size_t num) {
-	FILE *fp = fopen(filename, "r");
+	FILE *fp = fopen(filename, "rb");
 	if (!fp) {
 		return NULL;  // Can't open file.
 	}
@@ -77,7 +77,7 @@ void YASL_loadprinterr(struct YASL_State *S) {
 }
 
 int YASL_resetstate(struct YASL_State *S, const char *filename) {
-	FILE *fp = fopen(filename, "r");
+	FILE *fp = fopen(filename, "rb");
 	if (!fp) {
 		return YASL_ERROR;  // Can't open file.
 	}


### PR DESCRIPTION
Also, cleanup some spacing nit-picks and fix the targeting of `libdl` when cross-compiling for Windows by changing `UNIX`, which apparently cross-comping for Windows is, to `NOT WIN32` which produces the expected behavior when cross-compiling or building locally for Linux.

Finally, open with `rb` file-flags for all YASL state initialization functions.