### PR TITLE
Replace unconditional YASL_SUCCESS returns with void

### DIFF
--- a/std/yasl-std-collections.c
+++ b/std/yasl-std-collections.c
@@ -339,7 +339,7 @@ static int YASL_collections_set___get(struct YASL_State *S) {
 	return 1;
 }
 
-int YASL_decllib_collections(struct YASL_State *S) {
+void YASL_decllib_collections(struct YASL_State *S) {
 	YASL_pushtable(S);
 	YASL_registermt(S, SET_NAME);
 
@@ -385,6 +385,4 @@ int YASL_decllib_collections(struct YASL_State *S) {
 	YASL_pushcfunction(S, YASL_collections_table_new, -1);
 	YASL_tableset(S);
 	YASL_pop(S);
-
-	return YASL_SUCCESS;
 }

--- a/std/yasl-std-collections.h
+++ b/std/yasl-std-collections.h
@@ -3,6 +3,6 @@
 
 #include "yasl.h"
 
-int YASL_decllib_collections(struct YASL_State *S);
+void YASL_decllib_collections(struct YASL_State *S);
 
 #endif

--- a/std/yasl-std-error.c
+++ b/std/yasl-std-error.c
@@ -17,12 +17,11 @@ int YASL_error(struct YASL_State *S) {
 	YASL_print_err(S, "Error: %s", str);
 	free(str);
 	YASL_throw_err(S, YASL_ERROR);
+	return YASL_SUCCESS;
 }
 
-int YASL_decllib_error(struct YASL_State *S) {
+void YASL_decllib_error(struct YASL_State *S) {
 	YASL_declglobal(S, "error");
 	YASL_pushcfunction(S, YASL_error, 1);
 	YASL_setglobal(S, "error");
-
-	return YASL_SUCCESS;
 }

--- a/std/yasl-std-error.h
+++ b/std/yasl-std-error.h
@@ -3,6 +3,6 @@
 
 #include "yasl.h"
 
-int YASL_decllib_error(struct YASL_State *S);
+void YASL_decllib_error(struct YASL_State *S);
 
 #endif

--- a/std/yasl-std-io.c
+++ b/std/yasl-std-io.c
@@ -246,7 +246,7 @@ static int YASL_io_close(struct YASL_State *S) {
 	return 1;
 }
 
-int YASL_decllib_io(struct YASL_State *S) {
+void YASL_decllib_io(struct YASL_State *S) {
 	YASL_pushtable(S);
 	YASL_registermt(S, FILE_NAME);
 
@@ -290,6 +290,4 @@ int YASL_decllib_io(struct YASL_State *S) {
 	YASL_setmt(S);
 	YASL_tableset(S);
 	YASL_pop(S);
-
-	return YASL_SUCCESS;
 }

--- a/std/yasl-std-io.h
+++ b/std/yasl-std-io.h
@@ -3,6 +3,6 @@
 
 #include "yasl.h"
 
-int YASL_decllib_io(struct YASL_State *S);
+void YASL_decllib_io(struct YASL_State *S);
 
 #endif

--- a/std/yasl-std-math.c
+++ b/std/yasl-std-math.c
@@ -333,7 +333,7 @@ static int YASL_math_seed(struct YASL_State *S) {
 	return 0;
 }
 
-int YASL_decllib_math(struct YASL_State *S) {
+void YASL_decllib_math(struct YASL_State *S) {
 	YASL_declglobal(S, "math");
 	YASL_pushtable(S);
 	YASL_setglobal(S, "math");
@@ -380,7 +380,4 @@ int YASL_decllib_math(struct YASL_State *S) {
 
 	YASLX_tablesetfunctions(S, functions);
 	YASL_pop(S);
-
-	return YASL_SUCCESS;
 }
-

--- a/std/yasl-std-math.h
+++ b/std/yasl-std-math.h
@@ -3,6 +3,6 @@
 
 #include "yasl.h"
 
-int YASL_decllib_math(struct YASL_State *S);
+void YASL_decllib_math(struct YASL_State *S);
 
 #endif

--- a/std/yasl-std-mt.c
+++ b/std/yasl-std-mt.c
@@ -62,7 +62,7 @@ int YASL_mt_lookup(struct YASL_State *S) {
 	return 1;
 }
 
-int YASL_decllib_mt(struct YASL_State *S) {
+void YASL_decllib_mt(struct YASL_State *S) {
 	YASL_declglobal(S, "mt");
 	YASL_pushtable(S);
 	YASL_setglobal(S, "mt");
@@ -79,6 +79,4 @@ int YASL_decllib_mt(struct YASL_State *S) {
 
 	YASLX_tablesetfunctions(S, functions);
 	YASL_pop(S);
-
-	return YASL_SUCCESS;
 }

--- a/std/yasl-std-mt.h
+++ b/std/yasl-std-mt.h
@@ -3,6 +3,6 @@
 
 #include "yasl.h"
 
-int YASL_decllib_mt(struct YASL_State *S);
+void YASL_decllib_mt(struct YASL_State *S);
 
 #endif

--- a/std/yasl-std-require.c
+++ b/std/yasl-std-require.c
@@ -189,18 +189,14 @@ int YASL_require_c(struct YASL_State *S) {
 	return 1;
 }
 
-int YASL_decllib_require(struct YASL_State *S) {
+void YASL_decllib_require(struct YASL_State *S) {
 	YASL_declglobal(S, "require");
 	YASL_pushcfunction(S, YASL_require, 1);
 	YASL_setglobal(S, "require");
-
-	return YASL_SUCCESS;
 }
 
-int YASL_decllib_require_c(struct YASL_State *S) {
+void YASL_decllib_require_c(struct YASL_State *S) {
 	YASL_declglobal(S, "__require_c__");
 	YASL_pushcfunction(S, YASL_require_c, 1);
 	YASL_setglobal(S, "__require_c__");
-
-	return YASL_SUCCESS;
 }

--- a/std/yasl-std-require.h
+++ b/std/yasl-std-require.h
@@ -3,7 +3,7 @@
 
 #include "yasl.h"
 
-int YASL_decllib_require(struct YASL_State *S);
-int YASL_decllib_require_c(struct YASL_State *S);
+void YASL_decllib_require(struct YASL_State *S);
+void YASL_decllib_require_c(struct YASL_State *S);
 
 #endif

--- a/test/integration_tests.c
+++ b/test/integration_tests.c
@@ -30,9 +30,9 @@ for (size_t i = 0; i < sizeof(inputs) / sizeof(char *); i++) {\
 	size_t read = fread(expected_output, 1, size, f);\
 	expected_output[read] = '\0';\
 	S = YASL_newstate(inputs[i]);\
-	int status = YASLX_decllibs(S);\
+	YASLX_decllibs(S);\
 	YASL_setprintout_tostr(S);\
-	status |= YASL_execute(S);\
+	int status = YASL_execute(S);\
 	YASL_loadprintout(S);\
 	char *actual_output = YASL_peekcstr(S);\
 	if (!!strcmp(expected_output, actual_output) || status != YASL_SUCCESS) {\

--- a/test/unit_tests/test_api/deltest.c
+++ b/test/unit_tests/test_api/deltest.c
@@ -5,7 +5,7 @@
 SETUP_YATS();
 
 static void testnull(void) {
-	ASSERT_SUCCESS(YASL_delstate(NULL));
+	YASL_delstate(NULL);
 }
 
 TEST(deltest) {

--- a/test/unit_tests/test_api/listitertest.c
+++ b/test/unit_tests/test_api/listitertest.c
@@ -7,7 +7,7 @@ SETUP_YATS();
 static void testlistiter(void) {
 	const char *code = "x = [ 10, 9, 8, 7, 6 ];";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	ASSERT_SUCCESS(YASL_execute(S));
 	ASSERT_SUCCESS(YASL_loadglobal(S, "x"));
 	ASSERT(YASL_isnlist(S, 0));

--- a/test/unit_tests/test_api/poptest.c
+++ b/test/unit_tests/test_api/poptest.c
@@ -7,7 +7,7 @@ SETUP_YATS();
 static void testpopfloat(void) {
 	const char *code = "x = 12.5;";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	ASSERT_SUCCESS(YASL_execute(S));
 	ASSERT_SUCCESS(YASL_loadglobal(S, "x"));
 	ASSERT(YASL_isnfloat(S, 0));
@@ -18,7 +18,7 @@ static void testpopfloat(void) {
 static void testpopint(void) {
 	const char *code = "x = 12;";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	ASSERT_SUCCESS(YASL_execute(S));
 	ASSERT_SUCCESS(YASL_loadglobal(S, "x"));
 	ASSERT(YASL_isnint(S, 0));
@@ -29,7 +29,7 @@ static void testpopint(void) {
 static void testpopbool(void) {
 	const char *code = "x = true;";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	ASSERT_SUCCESS(YASL_execute(S));
 	ASSERT_SUCCESS(YASL_loadglobal(S, "x"));
 	ASSERT(YASL_isnbool(S, 0));
@@ -48,11 +48,11 @@ static void testpopuserptr(void) {
 	char x[] = "hello world";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
 
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushuserptr(S, x);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 
-	ASSERT_SUCCESS(YASL_declglobal(S, "f"));
+	YASL_declglobal(S, "f");
 	YASL_pushcfunction(S, testpop_userptr_helper, 1);
 	ASSERT_SUCCESS(YASL_setglobal(S, "f"));
 

--- a/test/unit_tests/test_api/pushtest.c
+++ b/test/unit_tests/test_api/pushtest.c
@@ -13,7 +13,7 @@ static void testrun(void) {
 static void testsetglobal_undef(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushundef(S);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));
@@ -23,7 +23,7 @@ static void testsetglobal_undef(void) {
 static void testsetglobal_float(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushfloat(S, 12.5);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));
@@ -33,7 +33,7 @@ static void testsetglobal_float(void) {
 static void testsetglobal_bool(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushbool(S, true);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));
@@ -43,7 +43,7 @@ static void testsetglobal_bool(void) {
 static void testsetglobal_int(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushint(S, 12);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));
@@ -55,7 +55,7 @@ static void testsetglobal_szstr(void) {
 	char *tmp = (char *)malloc(strlen("hello world") + 1);
 	strcpy(tmp, "hello world");
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushzstr(S, tmp);
 	free(tmp);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
@@ -66,7 +66,7 @@ static void testsetglobal_szstr(void) {
 static void testsetglobal_litstr(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushlit(S, "hello world");
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));
@@ -76,7 +76,7 @@ static void testsetglobal_litstr(void) {
 static void testsetglobal_list(void) {
 	struct YASL_State *S = YASL_newstate_bb("echo x;", strlen("echo x;"));
 	S->vm.out.print = io_print_string;
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	YASL_pushlist(S);
 	ASSERT_SUCCESS(YASL_setglobal(S, "x"));
 	ASSERT_SUCCESS(YASL_execute(S));

--- a/test/unit_tests/test_api/tablenexttest.c
+++ b/test/unit_tests/test_api/tablenexttest.c
@@ -7,7 +7,7 @@ SETUP_YATS();
 static void testtablenext(void) {
 	const char *code = "x = { 1: 1.0, 2: 2.0, 3: 3.0 };";
 	struct YASL_State *S = YASL_newstate_bb(code, strlen(code));
-	ASSERT_SUCCESS(YASL_declglobal(S, "x"));
+	YASL_declglobal(S, "x");
 	ASSERT_SUCCESS(YASL_execute(S));
 	ASSERT_SUCCESS(YASL_loadglobal(S, "x"));
 	ASSERT(YASL_istable(S));

--- a/yasl.c
+++ b/yasl.c
@@ -111,7 +111,7 @@ struct YASL_State *YASL_newstate_bb(const char *buf, size_t len) {
 }
 
 
-int YASL_resetstate_bb(struct YASL_State *S, const char *buf, size_t len) {
+void YASL_resetstate_bb(struct YASL_State *S, const char *buf, size_t len) {
 	S->compiler.status = YASL_SUCCESS;
 	S->compiler.parser.status = YASL_SUCCESS;
 	lex_cleanup(&S->compiler.parser.lex);
@@ -122,17 +122,14 @@ int YASL_resetstate_bb(struct YASL_State *S, const char *buf, size_t len) {
 
 	if (S->vm.code)	free(S->vm.code);
 	S->vm.code = NULL;
-
-	return YASL_SUCCESS;
 }
 
-int YASL_delstate(struct YASL_State *S) {
-	if (!S) return YASL_SUCCESS;
+void YASL_delstate(struct YASL_State *S) {
+	if (!S) return;
 
 	compiler_cleanup(&S->compiler);
 	vm_cleanup((struct VM *) S);
 	free(S);
-	return YASL_SUCCESS;
 }
 
 void YASL_setprintout_tostr(struct YASL_State *S) {
@@ -188,12 +185,10 @@ int YASL_execute(struct YASL_State *S) {
 	S->vm.code = bc;
 	S->vm.headers[S->compiler.num] = bc;
 
-	int result = vm_run((struct VM *) S);  // TODO: error handling for runtime errors.
-
-	return result;
+	return vm_run((struct VM *) S);  // TODO: error handling for runtime errors.
 }
 
-int YASL_declglobal(struct YASL_State *S, const char *name) {
+void YASL_declglobal(struct YASL_State *S, const char *name) {
 #ifdef YASL_DEBUG
 	const char *curr = name;
 	YASL_ASSERT(*curr, "name must be at least length 1.");
@@ -206,7 +201,6 @@ int YASL_declglobal(struct YASL_State *S, const char *name) {
 #endif  // YASL_DEBUG
 	compiler_intern_string(&S->compiler, name, strlen(name));
 	scope_decl_var(S->compiler.globals, name);
-	return YASL_SUCCESS;
 }
 
 static inline int is_const(int64_t value) {
@@ -238,12 +232,10 @@ int YASL_loadglobal(struct YASL_State *S, const char *name) {
 	return YASL_SUCCESS;
 }
 
-int YASL_registermt(struct YASL_State *S, const char *name) {
+void YASL_registermt(struct YASL_State *S, const char *name) {
 	struct YASL_String *string = YASL_String_new_sized(strlen(name), name);
 	YASL_Table_insert_fast(S->vm.metatables, YASL_STR(string), vm_peek((struct VM *) S));
 	YASL_pop(S);
-
-	return YASL_SUCCESS;
 }
 
 int YASL_loadmt(struct YASL_State *S, const char *name) {
@@ -398,10 +390,9 @@ void YASL_pop(struct YASL_State *S) {
 	vm_pop(&S->vm);
 }
 
-int YASL_duptop(struct YASL_State *S) {
+void YASL_duptop(struct YASL_State *S) {
 	YASL_ASSERT(S->vm.sp >= 0, "Cannot duplicate top of empty stack.");
 	vm_push(&S->vm, vm_peek(&S->vm));
-	return YASL_SUCCESS;
 }
 
 void YASL_stringifytop(struct YASL_State *S) {

--- a/yasl.h
+++ b/yasl.h
@@ -36,32 +36,29 @@ int YASL_compile(struct YASL_State *S);
  * not handle the lifetime of the string; normally a literal is used.
  * @param S the YASL_State in which to declare the global.
  * @param name the name of the global (null-terminated string).
- * @return YASL_SUCCESS on success, otherwise an error code.
  */
-int YASL_declglobal(struct YASL_State *S, const char *name);
+void YASL_declglobal(struct YASL_State *S, const char *name);
 
-int YASL_decllib_collections(struct YASL_State *S);
-int YASL_decllib_error(struct YASL_State *S);
-int YASL_decllib_io(struct YASL_State *S);
-int YASL_decllib_math(struct YASL_State *S);
-int YASL_decllib_require(struct YASL_State *S);
-int YASL_decllib_require_c(struct YASL_State *S);
-int YASL_decllib_mt(struct YASL_State *S);
+void YASL_decllib_collections(struct YASL_State *S);
+void YASL_decllib_error(struct YASL_State *S);
+void YASL_decllib_io(struct YASL_State *S);
+void YASL_decllib_math(struct YASL_State *S);
+void YASL_decllib_require(struct YASL_State *S);
+void YASL_decllib_require_c(struct YASL_State *S);
+void YASL_decllib_mt(struct YASL_State *S);
 
 /**
  * deletes the given YASL_State.
  * @param S YASL_State to be deleted.
- * @return 0 on success, otherwise an error code.
  */
-int YASL_delstate(struct YASL_State *S);
+void YASL_delstate(struct YASL_State *S);
 
 /**
  * [-0, +1]
  * Duplicates the top of the stack.
  * @param S the YASL_State.
- * @return YASL_SUCCESS on success, otherwise an error code.
  */
-int YASL_duptop(struct YASL_State *S);
+void YASL_duptop(struct YASL_State *S);
 
 /**
  * [-0, +0]
@@ -578,9 +575,8 @@ void YASL_pushzstr(struct YASL_State *S, const char *value);
  * with metatables, e.g. `YASL_setmt` or `YASL_loadmt`.
  * @param S the YASL_State.
  * @param name the name of the metatable.
- * @return YASL_SUCCESS.
  */
-int YASL_registermt(struct YASL_State *S, const char *name);
+void YASL_registermt(struct YASL_State *S, const char *name);
 
 /**
  * resets S to the same state it would be in if newly created using
@@ -597,9 +593,8 @@ int YASL_resetstate(struct YASL_State *S, const char *filename);
  * @param S the YASL_State.
  * @param buf the buffer used to initialize S.
  * @param len the length of buf.
- * @return YASL_SUCCESS on success, else an error code.
  */
-int YASL_resetstate_bb(struct YASL_State *S, const char *buf, size_t len);
+void YASL_resetstate_bb(struct YASL_State *S, const char *buf, size_t len);
 
 /**
  * [-1, +0]

--- a/yasl_aux.c
+++ b/yasl_aux.c
@@ -1,7 +1,7 @@
 #include "yasl_aux.h"
 #include "yasl_include.h"
 
-int YASLX_decllibs(struct YASL_State *S) {
+void YASLX_decllibs(struct YASL_State *S) {
 	YASL_decllib_collections(S);
 	YASL_decllib_error(S);
 	YASL_decllib_io(S);
@@ -9,8 +9,6 @@ int YASLX_decllibs(struct YASL_State *S) {
 	YASL_decllib_require(S);
 	YASL_decllib_require_c(S);
 	YASL_decllib_mt(S);
-
-	return YASL_SUCCESS;
 }
 
 void YASLX_initglobal(struct YASL_State *S, const char *name) {

--- a/yasl_aux.h
+++ b/yasl_aux.h
@@ -11,9 +11,8 @@
 /**
  * Loads all standard libraries into the appropriate state and declares them all with their default names.
  * @param S The state onto which to load the libraries.
- * @return YASL_SUCESS on success, else error code.
  */
-int YASLX_decllibs(struct YASL_State *S);
+void YASLX_decllibs(struct YASL_State *S);
 
 /**
  * Declares a global and initializes it with the top value from the stack.


### PR DESCRIPTION
In my effort to satisfy Rust's type safety I realized that a handful of function that ostensibly return an error code in fact are never-fail scenarios. This PR represents the culmination of those investigations 😛