### PR TITLE
Explicitly state that the function array does not need to be mutable

### DIFF
--- a/yasl_aux.c
+++ b/yasl_aux.c
@@ -69,7 +69,7 @@ static bool YASLX_functions_issentinal(struct YASLX_function functions) {
 	return functions.name == NULL && functions.fn == NULL && functions.args == 0;
 }
 
-void YASLX_tablesetfunctions(struct YASL_State *S, struct YASLX_function functions[]) {
+void YASLX_tablesetfunctions(struct YASL_State *S, const struct YASLX_function functions[]) {
 	for (int i = 0; !YASLX_functions_issentinal(functions[i]); i++) {
 		struct YASLX_function function = functions[i];
 		YASL_pushlit(S, function.name);

--- a/yasl_aux.h
+++ b/yasl_aux.h
@@ -94,6 +94,6 @@ struct YASLX_function {
  * @param S The YASL_State
  * @param functions array of function names, function pointers, and number of args.
  */
-void YASLX_tablesetfunctions(struct YASL_State *S, struct YASLX_function functions[]);
+void YASLX_tablesetfunctions(struct YASL_State *S, const struct YASLX_function functions[]);
 
 #endif


### PR DESCRIPTION
I think this is the correct way to specify the API change I want to effect. The goal is for API binding to make it explicit that `const` references are all that's required.