### PR TITLE
Add missing function declaration and definitions

### DIFF
--- a/yasl.c
+++ b/yasl.c
@@ -285,6 +285,14 @@ const char *YASL_peekntypestr(struct YASL_State *S, unsigned n) {
 	return YASL_peekntypename(S, n);
 }
 
+void *YASL_peekuserdata(struct YASL_State *S) {
+	return YASL_GETUSERDATA(vm_peek(&S->vm))->data;
+}
+
+void *YASL_peekuserptr(struct YASL_State *S) {
+	return YASL_GETUSERPTR(vm_peek(&S->vm));
+}
+
 void YASL_pushundef(struct YASL_State *S) {
 	vm_push((struct VM *) S, YASL_UNDEF());
 }

--- a/yasl.h
+++ b/yasl.h
@@ -391,6 +391,14 @@ int YASL_peektype(struct YASL_State *S);
 
 /**
  * [-0, +0]
+ * returns the type of object at index n.
+ * @param S the YASL_State.
+ * @return the type on top of the stack.
+ */
+int YASL_peekntype(struct YASL_State *S, unsigned n);
+
+/**
+ * [-0, +0]
  * returns the type of the top of the stack as a string.
  * @param S the YASL_State to which the stack belongs.
  * @return the string representation of the type on top of the stack.


### PR DESCRIPTION
I discovered two functions which were delcared in `yasl.h` but not implemented and one function which was implemented but not exported in `yasl.h`.